### PR TITLE
docs(README): add "Contributing" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 DesignSafe ReadTheDocs Documentation with [MkDocs](https://mkdocs.readthedocs.io/).
 
+## Contributing
+
+> [!NOTE]
+> For a detailed walkthrough of how to contribute to [Use Cases](https://www.designsafe-ci.org/user-guide/usecases/), see [its upcoming README](https://github.com/DesignSafe-CI/DS-User-Guide/blob/feat/DES-2668-migrate-isolated-use-cases-to-here/user-guide/docs/usecases/README.md).
+
+1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this repository.\
+    <sup>(unless you are a direct collaborator)</sup>
+2. [Edit](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files) relevant files that need update.\
+    <sup>([upload images](https://docs.github.com/en/repositories/working-with-files/managing-files/adding-a-file-to-a-repository) as necessary)</sup>
+4. [Commit](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits) your changes.
+5. [Create a "Pull Request".](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+
 ## Local Development
 
 ### Using Local Environment


### PR DESCRIPTION
## Overview

Add a "Contributing" section to the README.

## Notes

The repo is now public. And https://github.com/DesignSafe-CI/DS-User-Guide/pull/12 is coming. README should reflect this.