### PR TITLE
Update guides.md

### DIFF
--- a/user-guide/docs/curating/guides.md
+++ b/user-guide/docs/curating/guides.md
@@ -133,6 +133,8 @@ Finally, click <strong>Request DOI &amp; Publish</strong> and agree to the agree
 
 ### [Simulation](#simulation) { #simulation }
 
+We recommend reading the Best Practices Guide for [Simulation Data](../../bestpractices/working#simulationdata) as a prerequesite to initiating your project.
+
 #### [1. Add a Project](#simulation-step1) { #simulation-step1 }
 
 You can start a project at the very beginning of its lifespan, upload and curate data incrementally, then publish sets of data at your convenience.


### PR DESCRIPTION
Please first approve my earlier PR for the update to bestpractices.md.  This PR adds a sentence under the Simulation section that references the new section in bestpractices.md.  I'm not confident in how I linked to the reference in best practices, so please double-check that.  I wrote:
We recommend reading the Best Practices Guide for [Simulation Data](../../bestpractices/working#simulationdata) as a prerequesite to initiating your project.