### PR TITLE
fix(docs): usecases overview broken outdated links

### DIFF
--- a/user-guide/docs/usecases/overview.md
+++ b/user-guide/docs/usecases/overview.md
@@ -17,11 +17,13 @@ To help users fully embrace DesignSafe functionalities, we have developed a suit
 
 ### Seismic Use Cases 
 
-* [**Site Response Analysis and Model Calibration**](#opensees-model-calibration) (OpenSees, SimCenter quoFEM, Jupyter, HPC)
-* [**Simulating the Seismic Performance of Reinforced Concrete Walls**](#seismic-response-of-concrete-walls) (OpenSees, Jupyter, HPC)
-* [**Soil-Structure-Interaction Simulations**](#soil-structure-interaction) (OpenSees, STKO, Jupyter, HPC)
-* [**Experimental Visualization of Shaking Table Data**](#experimental-shake-table-testing) (Jupyter, Interactive Data Analysis, UCSD NHERI Facility)
-* [**Shake Table Data Analysis Using ML**](#shake-table-data-analysis-using-ml) 
+* [**Simulating the Seismic Performance of Reinforced Concrete Walls**](lowes/usecase.md) (OpenSees, Jupyter, HPC)
+* [**Soil-Structure-Interaction Simulations**](rathje/usecase.md) (OpenSees, STKO, Jupyter, HPC)
+* [**Experimental Visualization of Shaking Table Data**](mosqueda/usecase.md) (Jupyter, Interactive Data Analysis, UCSD NHERI Facility)
+* [**Shake Table Data Analysis Using ML**](mosqueda/erler-mosqueda.md) 
+* [**Site Response Analysis and Model Calibration**](arduino/usecase.md) (OpenSees, SimCenter quoFEM, Jupyter, HPC)
+* [**Launching a Matlab script from a Jupyter notebook**](arduino/usecase_matlab.md) (Matlab, Jupyter, HPC)
+* [**Sensitivity Analysis, Bayesian Calibration and Forward Propagation of Uncertainties Using quoFEM**](arduino/usecase_quoFEM.md) (SimCenter quoFEM, Jupyter, HPC)
 
 ### Wind &amp; Storm Surge Use Cases
 


### PR DESCRIPTION
## Overview

Fix broken links and add missing links to Use Cases Overview page.

## Related

- borrows from https://github.com/DesignSafe-CI/DS-User-Guide/pull/5

## Changes

- **fixed** broken links
- **added** new related links

## Testing

1. Open http://0.0.0.0:8000/user-guide/usecases/overview/#seismic-use-cases.
2. Click all the links under "Seismic Use Cases" heading.
3. Verify each opens a page with the content described.

## UI

| before | after |
| - | - |
| ![before](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/a2d715da-92bb-4e36-8e61-cc6d3a73e8d1) | ![after](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/1ff6cd36-f02f-442c-893b-24356f54fa25) |

## Note

This page is a manual Table of Contents. It easily becomes out of sync with navigation. The nav sidebar itself already serves as an automatic Table of Contents that depends on heading levels of included files.