### PR TITLE
added 2 new use cases from Ahsan Kareem - stylesheet not style attr

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -61,7 +61,7 @@ hr:not(
     [role="main"] ~ footer *
 ) {
     border-top-color: #343131; /* copied from sidebar background */
-    margin-block: 5rem;
+    margin-block: 20rem 5rem;
 }
 
 

--- a/user-guide/docs/usecases/windstormsurgeusecases.md
+++ b/user-guide/docs/usecases/windstormsurgeusecases.md
@@ -6,35 +6,30 @@
 
 {% include-markdown 'pinelli/usecase.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  Hurricane Data Integration Visualization -->
 
 {% include-markdown 'pinelli/2usecase.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  ADCIRC Datasets -->
 
 {% include-markdown 'dawson/usecase2.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  Large-Scale Storm Surge -->
 
 {% include-markdown 'dawson/usecase.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  CFD Analysis of Winds on Structures -->
 
 {% include-markdown 'kareem/usecase.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  CFD Analysis of Winds on Low-Rise Building -->
@@ -42,7 +37,6 @@
 <!--- Silvia Mazzoni 5/29/2024. remove these comments after completion -->
 <!--- {% include-markdown 'kareem/usecase2.md' %} -->
 <!---  -->
-<!--- <hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/> -->
 <!--- --- -->
 <!--- end of comment -->
 
@@ -51,7 +45,6 @@
 <!--- Silvia Mazzoni 5/29/2024. remove these comments after completion -->
 <!--- {% include-markdown 'kareem/usecase3.md' %} -->
 <!---  -->
-<!--- <hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/> -->
 <!--- --- -->
 <!--- end of comment -->
 

--- a/user-guide/docs/usecases/workinprogress.md
+++ b/user-guide/docs/usecases/workinprogress.md
@@ -7,12 +7,10 @@ It has been published here for testing purposes.
 
 {% include-markdown 'kareem/usecase2.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---
 
 <!-- ##  Tamkang Database -->
 
 {% include-markdown 'kareem/usecase3.md' %}
 
-<hr style="border: dashed white 1.0px;background-color: white;height: 200.0px;"/>
 ---


### PR DESCRIPTION
## Overview

Illustrate how to use CSS via stylesheet, not `style `attribute.

## Status

> [!WARNING]
> Reference only. Feel free to cherry-pick.

## Related

- illustrates suggestion for #17

## Changes

- **changed** CSS for `hr`'s
- **removed** redundant `<hr>`'s

## Testing

1. Run docs.
2. Open http://0.0.0.0:8000/user-guide/usecases/workinprogress/.
3. Compare `<hr>` styling to #17.

## UI

| before i.e. #17 | after i.e. … |
| - | - |
| <img width="1200" alt="replicate html and inline styles" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/f28032a3-4146-452d-9ff3-adb2399ada1e"> | <img width="1200" alt="css update" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/f9cd93d4-78bf-48a9-a0d5-16d95942be9a"> |

## Notes

Original method had drawbacks:

1. redundant `<hr>`s
    <sub>Only one "horizontal rule" is necessary. Two is semantically inaccurate. If intent is styling, remember HTML is for structure and meaning, not styling.</sub>
2. duplicate complex code
    <sub>As seen in #17, updating the code requires updating duplicates of old instances.</sub>
3. inline styles
    <sub>Inline styling is one of the last resorts in CSS, because of a feature called specificity… basically, [`style` has the power of a Star Wars "Star Destroyer"](https://stuffandnonsense.co.uk/specisithity), which makes it difficulty to properly override via a stylesheet.</sub>