### PR TITLE
feat: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# global
+# TODO: Ask @susanunit
+# * @susanunit
+
+# architecture
+/*                 @wesleyboar
+/.github/          @wesleyboar
+/user-guide/themes @wesleyboar
+
+# settings
+/user-guide/docs/index.md @wesleyboar @susanunit
+/user-guide/mkdocs.yml    @wesleyboar @susanunit
+
+# OpenSees
+/user-guide/docs/tools/simulation/opensees.md  @silviamazzoni
+/user-guide/docs/tools/simulation/opensees/    @silviamazzoni
+/user-guide/docs/tools/simulation/openseesOld/ @silviamazzoni
+
+# ADCIRC
+/user-guide/docs/tools/simulation/adcirc.md @cdelcastillo21
+/user-guide/docs/tools/simulation/adcirc/   @cdelcastillo21
+
+# Arduino
+/user-guide/docs/usecases/arduino/ @parduino
+
+# static assets
+*.js  @wesleyboar
+js/   @wesleyboar
+*.css @wesleyboar
+css/  @wesleyboar


### PR DESCRIPTION
## Overview

Assign specific contributors to be code owners for a particular set of files.

## Related

- tested by #21

## Changes

- **added** [a `CODEOWNERS` file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

## Testing

> [!WARNING]
> I think I can only test after merge, because it is a file in `.github`.

1. Create a PR that edits any of the files owned by a "codeowner" that has "Write" permission.
2. Verify that "codeowner" is automatically added to the PR.

## UI

N/A