### PR TITLE
fix: hr's under h1's receive too much space

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -56,11 +56,14 @@ h6 {
 /* To make horizontal rules more obvious */
 /* FAQ: Our pages are so tall, that we will let users on big <hr>s */
 /* NOTE: Alternative UX is more difficult using our ReadTheDocs theme */
-hr:not(
+hr:where(:not(
     [role="navigation"] *,
     [role="main"] ~ footer *
-) {
+)) {
     border-top-color: #343131; /* copied from sidebar background */
+    margin-block: 5rem;
+}
+hr.spacer {
     margin-block: 20rem 5rem;
 }
 

--- a/user-guide/docs/usecases/windstormsurgeusecases.md
+++ b/user-guide/docs/usecases/windstormsurgeusecases.md
@@ -6,33 +6,28 @@
 
 {% include-markdown 'pinelli/usecase.md' %}
 
-
----
+<hr class="spacer" />
 
 <!-- ##  Hurricane Data Integration Visualization -->
 
 {% include-markdown 'pinelli/2usecase.md' %}
 
-
----
+<hr class="spacer" />
 
 <!-- ##  ADCIRC Datasets -->
 
 {% include-markdown 'dawson/usecase2.md' %}
-
----
+<hr class="spacer" />
 
 <!-- ##  Large-Scale Storm Surge -->
 
 {% include-markdown 'dawson/usecase.md' %}
-
----
+<hr class="spacer" />
 
 <!-- ##  CFD Analysis of Winds on Structures -->
 
 {% include-markdown 'kareem/usecase.md' %}
-
----
+<hr class="spacer" />
 
 <!-- ##  CFD Analysis of Winds on Low-Rise Building -->
 


### PR DESCRIPTION
## Overview

- Fix `hr`'s under `h1`'s receiving too much space.
- Isolate new `hr` styles into a class.
- Reduce default `hr` space.

## Related

> [!NOTE]
> Caused by me.

- introduced by #17
- suggested by #18

## Changes

- **moved** recent default `hr` styles into an `hr` class `spacer`

## Testing

1. Open http://0.0.0.0:8000/user-guide/usecases/windstormsurgeusecases/
2. Verify first `hr` does not have so much space above and below as later ones.

## UI

| first | next |
| - | - |
| <img width="1200" alt="Screenshot 2024-05-30 at 5 50 45 PM" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/b9c75549-4cd0-422d-8913-07d21c744022"> | <img width="1200" alt="Screenshot 2024-05-30 at 5 50 53 PM" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/645e2e4f-161c-4b17-8d45-b94ade88b0b5"> | 