### PR TITLE
feat: allow deeper navigation

### DIFF
--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -7,7 +7,7 @@ plugins:
 
 theme:
     name: readthedocs
-    navigation_depth: 3
+    navigation_depth: 4
     collapse_navigation: false
     custom_dir: themes/ds-readthedocs
     highlightjs: true


### PR DESCRIPTION
## Overview

Allow deeper navigation.

## Related

None

## Changes

- **changed** `navigation_depth` to `4`

## Testing

1. Checkout `feat/restore-verbose-navigation`.
2. Make this change.
3. Verify "1. The Interactive VM" child docs can show in navigation.

## UI

<details><summary>The change in this screenshot is not of this PR. It is of a branch (no PR yet) testing this change.</summary>

<img width="1200" alt="Screenshot 2024-05-30 at 6 06 42 PM" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/008d4e2c-c9d6-4ffb-b40e-ceeb9bdf65b5">

</details>