### PR TITLE
feat: silviamazzoni codeownwer of usecases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,9 @@
 # Arduino
 /user-guide/docs/usecases/arduino/ @parduino
 
+# Use Cases
+/user-guide/docs/usecases/ @silviamazzoni
+
 # static assets
 *.js  @wesleyboar
 js/   @wesleyboar


### PR DESCRIPTION
## Overview

Set @silviamazzoni as owner of `…/usecases/`

## Notes

I know the `CODEOWNERS` file has _existing_ errors. I will revisit them. This change does **not** introduce a _new_ error.