### PR TITLE
fix: long and short titles decoupled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM local/tacc-docs:v0.4.2
+FROM taccwma/tacc-docs:v0.4.2
 
 # To archive TACC code, before replacing it
 RUN mv /code /code-from-tacc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.4.2
+FROM taccwma/tacc-docs:v0.5.0
 
 # To archive TACC code, before replacing it
 RUN mv /code /code-from-tacc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.4.2
+FROM local/tacc-docs:v0.4.2
 
 # To archive TACC code, before replacing it
 RUN mv /code /code-from-tacc

--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -25,6 +25,7 @@
 
 /* TACC-DOCS */
 /* To customize TACC/TACC-Docs CSS */
+/* WARNING: These styles assume documentation is run "Via Docker" */
 /* https://github.com/TACC/TACC-Docs/blob/cbbf261/docs/css/core/tacc-docs.css */
 
 /* To force a logo `<img>` loading an SVG to have dimensions */
@@ -72,14 +73,26 @@ hr.spacer {
     margin-block: 20rem 5rem;
 }
 
-/* To remove space between a page header title and description of that header */
-/* https://github.com/mkdocs/mkdocs/blob/1.4.3/mkdocs/themes/readthedocs/css/theme.css */
-.rst-content header p {
+/* To both couple and distinguish short title and long title */
+.rst-content header p:is(#tacc-readthedocs *) {
     font-size: var(--global-font-size--xx-large);
     font-weight: var(--bold);
 }
-.rst-content header h2 {
+.rst-content header h2:is(#tacc-readthedocs *) {
     font-size: var(--global-font-size--x-large);
-    margin-bottom: -24px;
     font-weight: var(--regular);
+
+    /* To remove excess space between titles */
+    margin-bottom: -24px;
+}
+.rst-content header p:not(#tacc-readthedocs *) {
+    font-size: 150%;
+    font-weight: 700;
+}
+.rst-content header h2:not(#tacc-readthedocs *) {
+    font-size: 16px;
+    font-weight: unset;
+
+    /* To remove excess space between titles */
+    margin-bottom: 0.5em;
 }

--- a/user-guide/docs/usecases/arduino/usecase.md
+++ b/user-guide/docs/usecases/arduino/usecase.md
@@ -1,18 +1,18 @@
+/// html | header
+
 ## OpenSees Model Calibration
 
-<span style="font-size:1.5em;">
-**From constitutive parameter calibration to site response analysis**
-</span>
-<br><br>
-<span style="font-size:1.25em;">
-***A collection of educational notebooks to introduce model-parameter calibration and site response analysis using OpenSees in DesignSafe-CI***
-</span>
+From Constitutive Parameter Calibration to Site Response Analysis
+
+///
 
 **Pedro Arduino - University of Washington**  <br>
 **Sang-Ri Yi - SimCenter, UC Berkeley**  <br>
 **Aakash Bangalore Satish - SimCenter, UC Berkeley**
 
 *Key Words: quoFEM, OpenSees, Tapis, Python*
+
+A collection of educational notebooks to introduce model-parameter calibration and site response analysis using OpenSees in DesignSafe-CI.
 
 ### Resources
  

--- a/user-guide/docs/usecases/dawson/usecase.md
+++ b/user-guide/docs/usecases/dawson/usecase.md
@@ -1,12 +1,14 @@
+/// html | header
+
 ## Large-Scale Storm Surge
 
-<span style="font-size:1.5em;">
-**ADCIRC Use Case - Using Tapis and Pylauncher for Ensemble Modeling in DesignSafe**
-</span>
+ADCIRC Use Case - Using Tapis and Pylauncher for Ensemble Modeling in DesignSafe
+
+///
 
 **Clint Dawson, University of Texas at Austin**  <br>
 **Carlos del-Castillo-Negrete, University of Texas at Austin**   <br>
-**Benjamin Pachev, University of Texas at Austin**  
+**Benjamin Pachev, University of Texas at Austin**
 
 The following use case presents an example of how to leverage the Tapis API to run an ensemble of HPC simulations. The specific workflow to be presented consists of running ADCIRC, a storm-surge modeling application available on DesignSafe, using the parametric job launcher pylauncher. All code and examples presented are meant to be be executed from a Jupyter Notebook on the DesignSafe platform and using a DesignSafe account to make Tapis API calls. 
 

--- a/user-guide/docs/usecases/dawson/usecase.md
+++ b/user-guide/docs/usecases/dawson/usecase.md
@@ -8,7 +8,7 @@ ADCIRC Use Case - Using Tapis and Pylauncher for Ensemble Modeling in DesignSafe
 
 **Clint Dawson, University of Texas at Austin**  <br>
 **Carlos del-Castillo-Negrete, University of Texas at Austin**   <br>
-**Benjamin Pachev, University of Texas at Austin**
+**Benjamin Pachev, University of Texas at Austin**  
 
 The following use case presents an example of how to leverage the Tapis API to run an ensemble of HPC simulations. The specific workflow to be presented consists of running ADCIRC, a storm-surge modeling application available on DesignSafe, using the parametric job launcher pylauncher. All code and examples presented are meant to be be executed from a Jupyter Notebook on the DesignSafe platform and using a DesignSafe account to make Tapis API calls. 
 

--- a/user-guide/docs/usecases/dawson/usecase2.md
+++ b/user-guide/docs/usecases/dawson/usecase2.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## ADCIRC Datasets
 
-<span style="font-size:1.5em;">
-**ADCIRC Use Case - Creating an ADCIRC DataSet on DesignSafe**   
-</span>
+ADCIRC Use Case - Creating an ADCIRC DataSet on DesignSafe
+
+///
 
 **Clint Dawson, University of Texas at Austin** <br>
 **Carlos del-Castillo-Negrete, University of Texas at Austin**<br>

--- a/user-guide/docs/usecases/kareem/usecase.md
+++ b/user-guide/docs/usecases/kareem/usecase.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## CFD Analysis of Winds on Structures
 
-<span style="font-size:1.5em;">
-**CFD Simulations using the Jupyter Notebooks**  
-</span>
+CFD Simulations using the Jupyter Notebooks
+
+///
 
 **Fei Ding - [NatHaz Modeling Laboratory](https://nathaz.nd.edu/){target=_blank}, University of Notre Dame**<br>
 **Ahsan Kareem - [NatHaz Modeling Laboratory](https://nathaz.nd.edu/){target=_blank}, University of Notre Dame**<br>

--- a/user-guide/docs/usecases/kareem/usecase2.md
+++ b/user-guide/docs/usecases/kareem/usecase2.md
@@ -1,12 +1,15 @@
+/// html | header
+
 ## CFD Analysis of Winds on Low-Rise Building
 
-<span style="font-size:1.5em;">
-**Low-Rise Building CFD Simulations with Jupyter Notebook**  
-Implementation of ASCE Wind Speed Profiles and User-defined Wind Speed Profiles
-</span>
+Low-Rise Building CFD Simulations with Jupyter Notebook
+
+///
 
 
 **Ahsan Kareem - [NatHaz Modeling Laboratory](https://nathaz.nd.edu/){target=_blank}, University of Notre Dame**
+
+Implementation of ASCE Wind Speed Profiles and User-defined Wind Speed Profiles
 
 ### Resources
  

--- a/user-guide/docs/usecases/kareem/usecase3.md
+++ b/user-guide/docs/usecases/kareem/usecase3.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Tamkang Database
 
-<span style="font-size:1.5em;">
-**Tamkang Database**  
-</span>
+Tamkang Database
+
+///
 
 **D.K. Kwon - [NatHaz Modeling Laboratory](https://nathaz.nd.edu/){target=_blank}, University of Notre Dame**<br>
 **Ahsan Kareem - [NatHaz Modeling Laboratory](https://nathaz.nd.edu/){target=_blank}, University of Notre Dame**

--- a/user-guide/docs/usecases/mosqueda/erler-mosqueda.md
+++ b/user-guide/docs/usecases/mosqueda/erler-mosqueda.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Shake Table Data Analysis Using ML
 
-<span style="font-size:1.5em;">
-**Leveraging Machine Learning for Identification of Shake Table Data and Post Processing**
-</span>
+Leveraging Machine Learning for Identification of Shake Table Data and Post Processing
+
+///
 
 **Kayla Erler – University of California San Diego** <br>
 **Gilberto Mosqueda – University of California San Diego**

--- a/user-guide/docs/usecases/mosqueda/usecase.md
+++ b/user-guide/docs/usecases/mosqueda/usecase.md
@@ -1,7 +1,10 @@
+/// html | header
+
 ## Experimental Shake Table Testing
-<span style="font-size:1.5em;">
-**Integrated Workflow of Experiments using Jupyter Notebooks: *From Experimental Design to Publication*** 
-</span>
+
+Integrated Workflow of Experiments using Jupyter Notebooks: *From Experimental Design to Publication*
+
+///
 
 **Enrique Simbort - University of California, San Diego** <br>
 **Gilberto Mosqueda - University of California, San Diego**  

--- a/user-guide/docs/usecases/padgett/usecase.md
+++ b/user-guide/docs/usecases/padgett/usecase.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Visualizing Surge for Regional Risks
 
-<span style="font-size:1.5em;">
-**Integration of QGIS and Python Scripts to Model and Visualize Storm Impacts on Distributed Infrastructure Systems** 
-</span> 
+Integration of QGIS and Python Scripts to Model and Visualize Storm Impacts on Distributed Infrastructure Systems
+
+/// 
 
 **Catalina González-Dueñas and Jamie E. Padgett - Rice University**<br/>
 **Miku Fukatsu - Tokyo University of Science**

--- a/user-guide/docs/usecases/pinelli/2usecase.md
+++ b/user-guide/docs/usecases/pinelli/2usecase.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Hurricane Data Integration &amp; Visualization
 
-<span style="font-size:1.5em;">
-**Geospatial Hurricane Disaster Reconnaissance Data Integration and Visualization Using KeplerGl**  
-</span>
+Geospatial Hurricane Disaster Reconnaissance Data Integration and Visualization Using KeplerGl
+
+///
 
 **Pinelli, J.-P. – Florida Tech**    <br> 
 **Sziklay, E. – Florida Tech**  <br> 

--- a/user-guide/docs/usecases/pinelli/usecase.md
+++ b/user-guide/docs/usecases/pinelli/usecase.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Field Sensing Wind Events
 
-<span style="font-size:1.5em;">
-**Wind Data Analysis Tools**   
-</span>
+Wind Data Analysis Tools
+
+///
 
 **Soundarya Sridhar - Florida Institute of Technology**  
 **Jean-Paul Pinelli - Florida Institute of Technology**  

--- a/user-guide/docs/usecases/rathje/usecase.md
+++ b/user-guide/docs/usecases/rathje/usecase.md
@@ -1,8 +1,10 @@
+/// html | header
+
 ## Soil Structure Interaction
 
-<span style="font-size:1.5em;">
-**Integration of OpenSees-STKO-Jupyter to Simulate Seismic Response of Soil-Structure-Interaction**
-</span>
+Integration of OpenSees-STKO-Jupyter to Simulate Seismic Response of Soil-Structure-Interaction
+
+///
 
 **Yu-Wei Hwang - University of Texas at Austin**  <br>
 **Ellen Rathje - University of Texas at Austin**  


### PR DESCRIPTION
## Overview

Make long title and short/nav title look coupled (and short/nav title less important).

<details>

| before | after |
| - | - |
| ![before](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/f454a703-ec6a-4d9b-a388-7f55cde08ee3) | ![after](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/e4668754-33c2-4d26-a52f-5255c649359b) |

Before me:

1. The navigation had been using short titles, and the pages had been using long titles.
2. The documents were concatenated and navigation changed to match TACC user experience.
3. That caused navigation titles to differ from page titles.
4. A solution was implemented to put long and short titles on the page, so:
    - User could see the short nav title on the page, to check navigation.
    - User could see the long title on the page, to know the full name.

After me:

5. TACC styles made the short title and long title look less coupled.
6. I changed the markup so I could add CSS to:
    - visually couple the tiles
    - make short title be less important

After this PR:

7. We will review reverting to the old navigation (step 1).

</details>

## Related

<!--
- [DES-XYZ](https://tacc-main.atlassian.net/browse/DES-123)
- requires _some_other_pr_
- required by _some_other_pr_
-->

## Changes

- **changed** markup for use cases to couple long and short titles

## Testing

1. Open all use cases within http://localhost:8000/user-guide/usecases/seismicusecases/.
3. Verify nav titles (under "Seismic") match small title on each use case.
2. Open all use cases within http://localhost:8000/user-guide/usecases/windstormsurgeusecases/.
3. Verify nav titles (under "Wind and Storm Surge") match small title on each use case.

## UI

### Via Docker

| before | after |
| - | - |
| ![before](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/19b50f01-b44a-469c-aaf8-a7e9a9345b98) | ![after](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/3cf12e50-927b-4776-9dcb-8003847adeff) |

<details><summary>screenshots of all affected Use Cases <strong>after</strong> change</summary>

![Screenshot 2024-06-05 at 11 25 04 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/1a2bac77-a913-4be3-9119-dc429cb040bc)
![Screenshot 2024-06-05 at 11 25 10 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/c8b4bf90-ddea-4cff-997c-f276b968e290)
![Screenshot 2024-06-05 at 11 25 14 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/a6351f76-8d09-4f3f-88a8-2a55a1fa24e8)
![Screenshot 2024-06-05 at 11 25 18 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/0046c46b-b5dc-4fbf-b603-bda030b65dc7)
![Screenshot 2024-06-05 at 11 25 21 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/a7cc418f-de19-4dc2-bce8-0b8a2fd51bee)
![Screenshot 2024-06-05 at 11 25 25 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/2d071a96-a6dd-4c38-9e9a-cc6de3a91c88)
![Screenshot 2024-06-05 at 11 25 30 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/3bdeece6-7093-46de-9e78-58421cd1a933)
![Screenshot 2024-06-05 at 11 25 33 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/51d89ebc-1b8a-43db-a746-bc00efa77284)
![Screenshot 2024-06-05 at 11 25 37 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/7fc6243e-217b-4591-9d43-c11de311058f)
![Screenshot 2024-06-05 at 11 25 42 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/c886ecc0-57cd-4c4c-a592-6ae805d59810)
![Screenshot 2024-06-05 at 11 25 45 AM](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/f08ee3d1-db81-4f85-be07-d6ad0228659e)

</details>

### Via Python

| before | after |
| - | - |
| ![before](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/3b686336-f29f-46fc-a33d-5989c08ae1a9) | ![after](https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/3482d2dc-da50-4f93-9092-c76f8410f9dd) |