### PR TITLE
epic: redesign 2024 - refactor WI-157 from code to docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM taccwma/tacc-docs:v0.5.0
+FROM taccwma/tacc-docs:v0.6.0
 
-# To archive TACC code, before replacing it
-RUN mv /code /code-from-tacc
-COPY ./user-guide/ /code/
+# To archive TACC content, before replacing it
+RUN mv /docs /docs-from-tacc
+COPY ./user-guide/ /docs/
 
 # To restore required TACC files
-RUN cp -r  /code-from-tacc/mkdocs.base.yml /code/mkdocs.base.yml && \
-    rm -rf /code/docs/js/core && \
-    cp -r  /code-from-tacc/docs/js/core /code/docs/js/core && \
-    rm -rf /code/docs/css/core && \
-    cp -r  /code-from-tacc/docs/css/core /code/docs/css/core
-RUN mkdir -p /code/themes/ && \
-    rm -rf   /code/themes/tacc-readthedocs && \
-    cp -r    /code-from-tacc/themes/tacc-readthedocs /code/themes/tacc-readthedocs
+RUN cp -r  /docs-from-tacc/mkdocs.base.yml /docs/mkdocs.base.yml && \
+    rm -rf /docs/docs/js/core && \
+    cp -r  /docs-from-tacc/docs/js/core /docs/docs/js/core && \
+    rm -rf /docs/docs/css/core && \
+    cp -r  /docs-from-tacc/docs/css/core /docs/docs/css/core
+RUN mkdir -p /docs/themes/ && \
+    rm -rf   /docs/themes/tacc-readthedocs && \
+    cp -r    /docs-from-tacc/themes/tacc-readthedocs /docs/themes/tacc-readthedocs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
   docs:
     build: .
     volumes:
-      - ./user-guide/docs:/code/docs
-      - ./user-guide/mkdocs.yml:/code/mkdocs.yml
+      - ./user-guide/docs:/docs/docs
+      - ./user-guide/mkdocs.yml:/docs/mkdocs.yml
       # To retain TACC assets added during build
-      - skip-tacc-js:/code/docs/js/core
-      - skip-tacc-css:/code/docs/css/core
+      - skip-tacc-js:/docs/docs/js/core
+      - skip-tacc-css:/docs/docs/css/core
     ports:
       - 127.0.0.1:8000:8000
-    command: mkdocs serve --dev-addr 0.0.0.0:8000 --watch-theme --config-file /code/mkdocs.yml
+    command: mkdocs serve --dev-addr 0.0.0.0:8000 --watch-theme --config-file /docs/mkdocs.yml
     container_name: ds_docs
 
 volumes:


### PR DESCRIPTION
## Overview

Move docker content from `/code` to `/docs`.

<details>

Deploying #31 to prod is trouble if the content is in `/code` (new) instead of `/docs`.

</details>

## Related

- [WI-157](https://jira.tacc.utexas.edu/browse/WI-157)
- requires https://github.com/TACC/TACC-Docs/pull/33

## Changes

- **changed** docker content location from `/code` to `/docs`

## Testing

1. `make stop`
2. `make start`
3. `make build`
4. open https://localhost:8000
5. ✅ verify docs load

## UI

**Skipped.** The [(alternative) staging docs](https://pprd.docs.tacc.utexas.edu/) loads after [deploy](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/389/) of [build](https://github.com/DesignSafe-CI/DS-User-Guide/actions/runs/9423908249/job/25963179381).