### PR TITLE
feat: new account page, new nav section, smaller homepage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.7.0-2
+FROM taccwma/tacc-docs:v0.7.0
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.6.0
+FROM taccwma/tacc-docs:v0.7.0-2
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc

--- a/user-guide/docs/accounts.md
+++ b/user-guide/docs/accounts.md
@@ -1,0 +1,7 @@
+## User Account Registration, Password Reset, and Reactivation
+
+Any natural hazards researcher or practitioner that wants an environment to store, analyze, curate, publish, and discover data with a community of peers may register for an account. [**Request a user account**](https://www.designsafe-ci.org/account/register/), and then follow the instructions in the email you receive to complete setting up your account. You will then be able to [**log in to DesignSafe**](https://www.designsafe-ci.org/). A DesignSafe account is a TACC user account, so you will sometimes see emails from TACC and URLs that take you to the TACC domain tacc.utexas.edu.
+
+To **reset your password**, go to [https://accounts.tacc.utexas.edu/forgot_password](https://accounts.tacc.utexas.edu/forgot_password), enter your username or email address that is associated with your user account, and you will receive an email with a password reset link. 
+
+If you receive an **Authentication Failed** error when logging in, and you are confident that you have entered the correct password for your account, then it is likely that you need to **Reactivate Account** due to your account being Deactivated due to more than 120 days having passed since you last logged in. To reactivate your account, log in at accounts.tacc.utexas.edu and then request an activation link via [https://accounts.tacc.utexas.edu/activate](https://accounts.tacc.utexas.edu/activate). You will receive an email at the email address associated with your user account with instructions for account reactivation.

--- a/user-guide/docs/index.md
+++ b/user-guide/docs/index.md
@@ -1,22 +1,15 @@
 # DesignSafe User Guides
-*updated January 31, 2024*
 
-<strong>User Account Registration, Password Reset, and Reactivation</strong><br>
-Any natural hazards researcher or practitioner that wants an environment to store, analyze, curate, publish, and discover data with a community of peers may register for an account. <a href="https://www.designsafe-ci.org/account/register/" target="_blank"><strong>Request a user account</strong></a>, and then follow the instructions in the email you receive to complete setting up your account. You will then be able to <a href="https://www.designsafe-ci.org/" target="_blank">log in to DesignSafe</a>. A DesignSafe account is a TACC user account, so you will sometimes see emails from TACC and URLs that take you to the TACC domain tacc.utexas.edu.
+**Essentials**: [User Account Registration, Password Reset, and Reactivation](./accounts.md)
 
-To <strong>reset your password</strong>, go to https://accounts.tacc.utexas.edu/forgot_password, enter your username or email address that is associated with your user account, and you will receive an email with a password reset link. 
+---
 
-If you receive an <strong>Authentication Failed</strong> error when logging in, and you are confident that you have entered the correct password for your account, then it is likely that you need to <strong>Reactivate Account</strong> due to your account being Deactivated due to more than 120 days having passed since you last logged in. To reactivate your account, log in at accounts.tacc.utexas.edu and then request an activation link via https://accounts.tacc.utexas.edu/activate. You will receive an email at the email address associated with your user account with instructions for account reactivation.
-
-<strong>NAVIGATING THE USER GUIDE</strong><br>
 **Data Depot**: The Data Depot section provides documentation on managing your data including various methods to transfer your data to DesignSafe, guidance for including DesignSafe in your NSF Data Management Plan, and a checklist for data curation when working with a NHERI Experimental Facility. There is extensive guidance for curating and publishing your datasets for reuse by others including working with protected/regulated/sensitive data.
 
-**Tools &amp; Apps**: This section contains user guides for how to utilize our many offerings in data analytics, GIS and mapping, visualization, and our Jupyter Hub interacting with the data you bring to DesignSafe or that you discover in our Published datasets.
+**Tools and Apps**: This section contains user guides for how to utilize our many offerings in data analytics, GIS and mapping, visualization, and our Jupyter Hub interacting with the data you bring to DesignSafe or that you discover in our Published datasets.
 
 **Simulation Applications**: We host a wide array of open source and licensed software applications commonly used in natural hazards research.
 
 **Use Cases**: To help users fully embrace DesignSafe functionalities, we have developed a suite of Use Cases that demonstrate how DesignSafe is being used to advance natural hazards research. Practical products, examples, and scripts developed as part of these Use Cases are provided at the links below. The different simulation codes, tools, and DesignSafe resources used in each Use Case are also indicated.
 
 **Advanced Topics**: This section of the user guide provides information for how to request an HPC allocation to gain access to TACC's high performance computing resources when your research needs larger scale computation than the our portal applications provide. For researchers who develop their own software tools, a guide to how to use our API to access your data and run applications is provided. 
-
-

--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -34,6 +34,10 @@ plugins:
   - include-markdown
 
 nav:
+  - DesignSafe Essentials:
+    - Account Access: accounts.md
+    - Documentation Overview: index.md
+
   - Data Depot:
     - Managing Data: managingdata.md
     - Curating &amp; Publishing Projects: curating.md


### PR DESCRIPTION
## Overview

Update homepage. Move account access to new page. New top nav section.

> [!IMPORTANT]
> Reverted via 1ff87c8. Ready to review again in #67.

## Related

- closes #54
- avoids UI bug via [v0.7.0](https://github.com/TACC/TACC-Docs/releases/tag/v0.7.0)

## Changes

- **updated** tacc-docs version (to fix relevant nav UI bug)
- **removed** date last updated (can be found on GitHub)
- **moved** account access to its own page
- **changed** "Tools & Apps" to "Tools and Apps" (to match nav)
- **added** new nav section "DesignSafe Essentials" (like [TACC Docs](https://docs.tacc.utexas.edu/))

## Testing

1. Open http://0.0.0.0:8000/user-guide/.
2. See:
    - new nav section "DesignSafe Essentials"
    - new content "DesignSafe Essentials: …"
3. Verify **Documentation Outline** is highlighted (as current).
4. Click **Account Access**.

## UI

### Homepage & Nav

| before | after |
| - | - |
| <img width="1275" alt="before homepage change" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/c54c1c02-5724-4fd8-8c6e-6bf604aa57a7"> | <img width="1275" alt="after homepage change" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/746d360f-0974-4e6b-ab9f-9ac0aed06a64"> |

### Account Access

| before | after |
| - | - |
| <img width="1275" alt="before homepage change" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/c54c1c02-5724-4fd8-8c6e-6bf604aa57a7"> | <img width="1275" alt="account access" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/ad88fa7d-7cc3-4972-b726-ba85620a36a7"> |

<details><summary>

### TACC-Docs [v0.7.0](https://github.com/TACC/TACC-Docs/releases/tag/v0.7.0)

</summary>

Applies to new nav section, but also fixes one existing use case in current nav.

| before | after |
| - | - |
| <img width="1275" alt="before v070" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/4ccbaadf-ed00-4f65-9a76-777cd65a7063"> | <img width="1275" alt="after v070" src="https://github.com/DesignSafe-CI/DS-User-Guide/assets/62723358/8995c11f-f01e-42c9-aa54-2199937775c4"> |

</details>