### PR TITLE
fix: missing heading underline in card on hover

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -21,6 +21,16 @@
     --global-color-accent--xxx-dark: var(--color-accent-1-dark-3x);
 }
 
+/* To also support underlining headings in hovered card for `.h1` et cetera */
+/* https://github.com/DesignSafe-CI/DS-User-Guide/blob/df64c11/user-guide/docs/usecases/overview.md?plain=1#L34-L37 */
+/* https://github.com/TACC/Core-Styles/blob/v2.27.0/src/lib/_imports/components/c-card--docs.css#L23-L29 */
+[class*=card--]:hover :is( .h1, .h2, .h3, .h4, .h5, .h6 ) {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-thickness: var(--global-border-width--normal);
+    text-underline-offset: .2em;
+}
+
 
 
 /* TACC-DOCS */


### PR DESCRIPTION
## Overview

The heading within a card should be underline when user hovers on card.

## Related

- caused by #46 (https://github.com/DesignSafe-CI/DS-User-Guide/pull/46/commits/e990630)

## Changes

- **added** css

## Testing

1. Open http://localhost:8000/user-guide/usecases/overview/.
2. Hover over a card.
3. Verify heading is underlined.

## UI

https://github.com/user-attachments/assets/efc0ba71-a2a7-47b9-bc32-979fe152d81f

https://github.com/user-attachments/assets/2f4d563b-cb07-4b40-9480-c582011a86a7