### PR TITLE
fix: anchor link icon ux is distracting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.8.1
+FROM taccwma/tacc-docs:v0.8.2
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc

--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -115,3 +115,8 @@ hr.spacer {
 [data-page-name$="usecases/overview.md"] .wy-nav-content {
   padding-bottom: 0; /* undo theme.css */
 }
+
+/* To hide anchor link for deeper headings */
+:is(h4, h5, h6) .headerlink {
+  display: none;
+}


### PR DESCRIPTION
## Overview

The anchor link UX is too distracting:
- too visible
- too common

## Related

- fixes #39
- requires https://github.com/TACC/TACC-Docs/pull/41

## Changes

- **changed** styles
    - **smaller** icon
    - show **only** on hover over heading and icon
    - show at **lower opacity**
    - hover on icon gives **no underline**

## Testing

1. Load page.
2. Interact with heading anchor link.

## UI

See https://github.com/TACC/TACC-Docs/pull/41.