### PR TITLE
feat: simulate DesignSafe logo in headings

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -120,3 +120,19 @@ hr.spacer {
 :is(h4, h5, h6) .headerlink {
   display: none;
 }
+
+/* To write "DESIGNSAFE" like its logo */
+/* FAQ: To use, write `# <u><b>Design</b>Safe</u>` */
+:where(h1, h2, h3, h4, h5, h6) > u {
+  text-transform: uppercase;
+  text-decoration: none;
+  font-weight: var(--medium);
+  color: #565656;
+
+  /* To use DesignSafe logo font */
+  font-family: Futura; /* WARNING: requires user have this font installed */
+}
+:where(h1, h2, h3, h4, h5, h6) > u > b {
+  color: #cb463f;
+  font-weight: var(--black);
+}

--- a/user-guide/docs/index.md
+++ b/user-guide/docs/index.md
@@ -1,4 +1,4 @@
-# DesignSafe User Guides
+# <u><b>Design</b>Safe</u> User Guides
 *updated January 31, 2024*
 
 <strong>User Account Registration, Password Reset, and Reactivation</strong><br>


### PR DESCRIPTION
## Overview

Allow logo to be simulated in headings with "DesignSafe".

## Related

Requested by @silviamazzoni. Approved by @wesleyboar without designer.

## Changes

- **added** CSS for certain markup to emulate DesignSafe logo
- **changed** index page heading to use logo emulation

## Testing

### On an OS without "Futura" Font e.g. Windows

1. Load index page.
2. Verify heading looks **similar** to logo.

### On an OS with "Futura" Font e.g. macOS

1. Load index page.
2. Verify heading looks **exactly** like logo.

## UI

| exact<br><sup>as on macOS</sup> | similar<br><sup>as on Windows</sup> |
| - | - |
| <img width="1050" alt="exact" src="https://github.com/user-attachments/assets/7684ed99-1e94-4db3-9d95-5cbcf8d8b1d9"> | <img width="1050" alt="similar" src="https://github.com/user-attachments/assets/2c20acbb-e26c-4a47-acb3-a40a560ad740"> |