### PR TITLE
fix: WP-602 'docker compose' cmd compat.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
+# WARNING: Using `docker-compose` is deprecated
+DOCKER_COMPOSE_CMD := $(shell if command -v docker-compose > /dev/null; then echo "docker-compose"; else echo "docker compose"; fi)
+
 .PHONY: build
 build:
-	docker-compose -f ./docker-compose.yml build
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.yml build
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.yml up
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.yml down
+	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down
 	# So assets are not re-used (even after `docker system prune --all --force`)
 	docker volume rm ds-user-guide_skip-tacc-js
 	docker volume rm ds-user-guide_skip-tacc-css

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ DesignSafe [MkDocs](https://mkdocs.readthedocs.io/) documentation with **customi
     ```
    Windows user:
    ```shell
-    docker-compose -f docker-compose.yml build
-    docker-compose -f docker-compose.yml up
+    docker compose -f docker-compose.yml build
+    docker compose -f docker-compose.yml up
 
     ```
 4. Open the website at the URL provided e.g.


### PR DESCRIPTION
## Overview

Docker v2 has different command for `docker compose`. Adjust Makefile to handle both based on availability.

## Related

- [WP-602](https://tacc-main.atlassian.net/browse/WP-602)
- mimics https://github.com/TACC/Core-CMS-Custom/pull/295
- mimics https://github.com/TACC/Core-CMS/pull/858
- similar to https://github.com/TACC/TACC-Docs/pull/48

## Changes

- **added** conditional `docker compose` command to Makefile
- **changed** `docker-compose` to `docker compose` in README

## Testing

1. `make build` — no error firing command from Makefile
2. `make start` — no error firing command from Makefile

## UI

Skipped.