### PR TITLE
fix: inaccurate Python instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,22 @@ DesignSafe [MkDocs](https://mkdocs.readthedocs.io/) documentation with **customi
 0. Have Python installed.\
     <sup>Known supported versions are [from 3.10 to 3.12](https://github.com/DesignSafe-CI/DS-User-Guide/blob/tacc/tacc-docs/pyproject.toml#L9).</sup>
 1. Navigate into your clone of this repo.
-2. Install dependencies:\
-    <sup>You should only need to do this once, or after a new release.</sup>
+2. Install software to manage dependencies:\
+    <sup>You should only need to do this once.</sup>
     ```shell
-    ./bin/tacc-setup.sh
     pip install poetry
 
     ```
-3. Isolate dependencies:
+3. Install/Update dependencies:\
+    <sup>You should only need to do this after new releases.</sup>
     ```shell
-    poetry shell
+    ./bin/tacc-setup.sh
+    poetry install
 
     ```
-4. Update & Serve the docs:
+4. Serve the docs:
     ```shell
-    poetry install
+    poetry shell
     cd user-guide
     mkdocs serve
 


### PR DESCRIPTION
## Overview

Fixed order and description of instructions for "Testing" "via Python".

## Changes

- **moved** `pip install poetry` to **its own** group
- **moved** `poetry install` **before** `poetry shell`
- **changed** instruction groups and descriptions

## Notes

The `poetry install` and `poetry shell` commands both activate a Poetry-managed virtual environment, which is helpful to avoid dependency conflicts for users who do not use virtual environments to isolate their projects.

The `poetry install` installs project dependencies _**within** the current virtual environment_. The `python shell` allows running commands for **installed** dependencies e.g. `mkdocs` _**within** the current virtual environment_.

If `poetry install` has not been run yet, then `poetry shell` would **not** offer `mkdocs`. When `mkdocs` is unavailable, user response may be to install `mkdocs`. Installing `mkdocs`, while in this state, can cause different problems depending on how it is done.

- **`pip install mkdocs`** would install latest version, not project version.
- **`poetry install`(` …`)** would fail.[^1]

[^1]: Because `poetry` is not installed within the virtual environment, because `poetry` is not a dependency of the project itself.