### PR TITLE
build: suggest "dev" custom tag, not "next"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_custom:
-        description: 'A custom docker image tag e.g. "next"'
+        description: 'A custom docker image tag e.g. "dev"'
         required: false
         type: string
   push:


### PR DESCRIPTION
The next server will be de-comissioned. Dev will remain in use.