### PR TITLE
docs: how to add use case to user guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM local/tacc-docs:v0.10.3-67-g7a119c6b
+FROM taccwma/tacc-docs:v0.10.1
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -185,5 +185,39 @@ After a minute or so a preview deployment of your use case will be available on 
 
 </details>
 
+### <a id="add-to-guide"></a> 12. Add Content to User Guide
+
+Include your document into one of the existing use case categories —
+
+- [API](./apiusecases.md)
+- [Data Analytics](./dataanalyticsusecases.md)
+- [Geohazard](./geohazardusecases.md)
+- [Seismic](./seismicusecases.md)
+- [Wind and Storm Surge](./windstormsurgeusecases.md)
+
+— e.g. in [`dataanalyticsusecases.md`](./dataanalyticsusecases.md), under —
+
+```md
+
+---
+
+<!-- ## Visualization of spatially distributed data -->
+
+{% include-markdown 'padgett/usecase_JN_viz.md' %}
+```
+
+— add —
+
+```md
+
+---
+
+<!-- ## Description of yur use case -->
+
+{% include-markdown 'your-usecase/usecase.md' %}
+```
+
+— so that it will show up on this User Guide.
+
 [DS-User-Guide]: https://github.com/DesignSafe-CI/DS-User-Guide/
 [DS_Use_Case_template]: https://github.com/DesignSafe-CI/DS_Use_Case_template/

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -185,9 +185,9 @@ After a minute or so a preview deployment of your use case will be available on 
 
 </details>
 
-### <a id="add-to-guide"></a> 12. Add Content to User Guide
+### <a id="add-to-guide"></a> 12. Add New Use Case to User Guide
 
-Include your document into one of the existing use case categories —
+If you have added a Use Case, include it into one of the existing use case categories —
 
 - [API](./apiusecases.md)
 - [Data Analytics](./dataanalyticsusecases.md)

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -187,13 +187,13 @@ After a minute or so a preview deployment of your use case will be available on 
 
 ### <a id="add-to-guide"></a> 12. Add New Use Case to User Guide
 
-If you have added a Use Case, include it into one of the existing use case categories —
+If you have added a Use Case, include it into one of the existing use case category documents —
 
-- [API](./apiusecases.md)
-- [Data Analytics](./dataanalyticsusecases.md)
-- [Geohazard](./geohazardusecases.md)
-- [Seismic](./seismicusecases.md)
-- [Wind and Storm Surge](./windstormsurgeusecases.md)
+- [`apiusecases.md` (API)](./apiusecases.md)
+- [`dataanalyticsusecases.md` (Data Analytics)](./dataanalyticsusecases.md)
+- [`geohazardusecases.md` (Geohazard)](./geohazardusecases.md)
+- [`seismicusecases.md` (Seismic)](./seismicusecases.md)
+- [`windstormsurgeusecases.md` (Wind and Storm Surge)](./windstormsurgeusecases.md)
 
 — e.g. in [`dataanalyticsusecases.md`](./dataanalyticsusecases.md), under —
 

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -212,7 +212,7 @@ If you have added a Use Case, include it into one of the existing use case categ
 
 ---
 
-<!-- ## Description of yur use case -->
+<!-- ## Description of your use case -->
 
 {% include-markdown 'your-usecase/usecase.md' %}
 ```

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -185,15 +185,17 @@ After a minute or so a preview deployment of your use case will be available on 
 
 </details>
 
-### <a id="add-to-guide"></a> 12. Add New Use Case to User Guide
+### <a id="add-to-guide"></a> 12. Add Use Case New to User Guide
 
 If you have added a Use Case, include it into one of the existing use case category documents —
 
-- [`apiusecases.md` (API)](./apiusecases.md)
-- [`dataanalyticsusecases.md` (Data Analytics)](./dataanalyticsusecases.md)
-- [`geohazardusecases.md` (Geohazard)](./geohazardusecases.md)
-- [`seismicusecases.md` (Seismic)](./seismicusecases.md)
-- [`windstormsurgeusecases.md` (Wind and Storm Surge)](./windstormsurgeusecases.md)
+| Category | Document |
+| - | - |
+| API | [`apiusecases.md`](./apiusecases.md) |
+| Data Analytics | [`dataanalyticsusecases.md`](./dataanalyticsusecases.md) |
+| Geohazard | [`geohazardusecases.md`](./geohazardusecases.md) |
+| Seismic | [`seismicusecases.md`](./seismicusecases.md) |
+| Wind and Storm Surge | [`windstormsurgeusecases.md`](./windstormsurgeusecases.md) |
 
 — so that it will show up on this User Guide.
 

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -195,29 +195,37 @@ If you have added a Use Case, include it into one of the existing use case categ
 - [`seismicusecases.md` (Seismic)](./seismicusecases.md)
 - [`windstormsurgeusecases.md` (Wind and Storm Surge)](./windstormsurgeusecases.md)
 
-— e.g. in [`dataanalyticsusecases.md`](./dataanalyticsusecases.md), under —
-
-```md
-
----
-
-<!-- ## Visualization of spatially distributed data -->
-
-{% include-markdown 'padgett/usecase_JN_viz.md' %}
-```
-
-— add —
-
-```md
-
----
-
-<!-- ## Description of yur use case -->
-
-{% include-markdown 'your-usecase/usecase.md' %}
-```
-
 — so that it will show up on this User Guide.
+
+#### Example
+
+To add to [`dataanalyticsusecases.md` (Data Analytics)](./dataanalyticsusecases.md):
+
+1. Find bottommost `{% include-markdown '…' %}` e.g.
+
+    ```md
+
+    ---
+
+    <!-- ## Visualization of spatially distributed data -->
+
+    {% include-markdown 'padgett/usecase_JN_viz.md' %}
+    ```
+
+    <sup>Bottommost include may be different since last update.</sup>
+
+2. Add an include to your document in the same way:
+
+    ```md
+
+    ---
+
+    <!-- ## Description of yur use case -->
+
+    {% include-markdown 'your-usecase/usecase.md' %}
+    ```
+
+    <sup>Edit this include to point to your use case.</sup>
 
 [DS-User-Guide]: https://github.com/DesignSafe-CI/DS-User-Guide/
 [DS_Use_Case_template]: https://github.com/DesignSafe-CI/DS_Use_Case_template/


### PR DESCRIPTION
### Overview

Add step 12 to Use Cases Readme. Tell user how to add new use case to the User Guide.

### Preview

[document `/user-guide/docs/usecases/README.md` <br><sup><sub>(on branch **docs/usecases-how-to-add-to-userguide**)</sub></sup>](https://github.com/DesignSafe-CI/DS-User-Guide/blob/docs/usecases-how-to-add-to-userguide/user-guide/docs/usecases/README.md#-12-add-use-case-new-to-user-guide)
