### PR TITLE
docs: simplify link to use cases readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ DesignSafe [MkDocs](https://mkdocs.readthedocs.io/) documentation with **customi
 
 ## Contributing
 
-> [!NOTE]
-> For a detailed walkthrough of how to contribute to [Use Cases](https://www.designsafe-ci.org/user-guide/usecases/), see [its README](https://github.com/DesignSafe-CI/DS-User-Guide/blob/main/user-guide/docs/usecases/README.md).
+[How to Contirbute to **Use Cases**](https://github.com/DesignSafe-CI/DS-User-Guide/blob/main/user-guide/docs/usecases/README.md)
+
+How to Contribute **Other Changes**:
 
 1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this repository.\
     <sup>(unless you are a direct collaborator)</sup>

--- a/user-guide/docs/usecases/README.md
+++ b/user-guide/docs/usecases/README.md
@@ -1,10 +1,12 @@
-# DesignSafe Use Case Template
+# DesignSafe Use Cases
+
+How to contribute to [DesignSafe Use Cases](https://www.designsafe-ci.org/user-guide/usecases/overview/).
 
 ## A Guide to Adding Your Use Case Project
 
 ### <a id="fork-repo"></a> 1. Fork Repo
 
-The Principal Investigator (PI) should [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the [DS User Guide repo][DS-User-Guide] to their own account. If prompted, select an organziation to create the fork.
+The Principal Investigator (PI) should [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) this [DS User Guide repo][DS-User-Guide] to their own account. If prompted, select an organziation to create the fork.
 
 | fork the repo |
 | - |


### PR DESCRIPTION
## Overview & Changes

A single link to Use Cases readme.

To not confuse readers with an initial link to Use Cases.

## UI

| main README | use cases README |
| - | - |
| <img width="505" alt="main readme" src="https://github.com/user-attachments/assets/6d0bddb7-5eb7-4009-b54c-48d551adca15"> | <img width="565" alt="use cases readme" src="https://github.com/user-attachments/assets/8b639e6f-2037-463b-9ba6-223eecb2b561"> |
