### PR TITLE
fix: support arm processor docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.10.1
+FROM taccwma/tacc-docs:v0.12.0
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ How to Contribute **Other Changes**:
 
 ### B. Via Docker
 
-> [!WARNING]
-> This method does **not** work on macOS with an M1 nor M2 chip ([details](https://github.com/DesignSafe-CI/DS-User-Guide/issues/51)).
-
 0. Have Docker installed.\
     <sup>We recommend doing so via [Docker-Desktop](https://www.docker.com/products/docker-desktop).</sup>
 1. Navigate into your clone of this repository.


### PR DESCRIPTION
## Overview

Support `make build` on `arm64` (e.g. macOS M1 and M2).

## Related

* fixes #51

## Changes

- **upgraded** TACC/TACC-Docs
- **removed** warning from README

## Testing

1. `make build`
2. `make start`
3. No errors.
4. Visit site.
5. Loads as normal.

## UI

<details><summary><code>make build</code></summary>

```log
make build
docker compose -f ./docker-compose.yml build
WARN[0000] /Users/wbomar/Code/DesignSafe-CI/ds-user-guide/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 11.6s (11/11) FINISHED        docker:desktop-linux
 => [docs internal] load build definition from Dockerfile  0.0s
 => => transferring dockerfile: 636B                       0.0s
 => [docs internal] load metadata for docker.io/taccwma/t  1.2s
 => [docs internal] load .dockerignore                     0.0s
 => => transferring context: 2B                            0.0s
 => [docs 1/5] FROM docker.io/taccwma/tacc-docs:v0.12.0@s  2.2s
 => => resolve docker.io/taccwma/tacc-docs:v0.12.0@sha256  0.0s
 => => sha256:8e31e1b12ec5c37f64bd42c2d11 8.05MB / 8.05MB  1.0s
 => => sha256:9ac802c0b434fce1cab25f759 42.49MB / 42.49MB  1.9s
 => => extracting sha256:8e31e1b12ec5c37f64bd42c2d1159fc2  0.2s
 => => extracting sha256:9ac802c0b434fce1cab25f7594d01a0d  0.2s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0d  0.0s
 => [docs internal] load build context                     0.1s
 => => transferring context: 63.31kB                       0.0s
 => [docs 2/5] RUN mv /docs /docs-from-tacc                0.4s
 => [docs 3/5] COPY ./user-guide/ /docs/                   0.6s
 => [docs 4/5] RUN cp -r  /docs-from-tacc/mkdocs.base.yml  0.1s
 => [docs 5/5] RUN mkdir -p /docs/themes/ &&     rm -rf    0.1s
 => [docs] exporting to image                              6.7s
 => => exporting layers                                    5.4s
 => => exporting manifest sha256:551cb5bf0ecea73759624990  0.0s
 => => exporting config sha256:0b62af01dedc3ef41d8a657150  0.0s
 => => exporting attestation manifest sha256:c16fa2f7ab29  0.0s
 => => exporting manifest list sha256:7b4f9243d974088f9e5  0.0s
 => => naming to docker.io/library/ds-user-guide-docs:lat  0.0s
 => => unpacking to docker.io/library/ds-user-guide-docs:  1.2s
 => [docs] resolving provenance for metadata file          0.0s
```

</details>

<details><summary><code>make start</code></summary>

```log
make start
docker compose -f docker-compose.yml up
WARN[0000] /Users/wbomar/Code/DesignSafe-CI/ds-user-guide/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 4/4
 ✔ Network ds-user-guide_default         Created           0.0s 
 ✔ Volume "ds-user-guide_skip-tacc-js"   Created           0.0s 
 ✔ Volume "ds-user-guide_skip-tacc-css"  Created           0.0s 
 ✔ Container ds_docs                     Created           0.1s 
Attaching to ds_docs
ds_docs  | WARNING  -  Config value 'site_favicon': Unrecognised configuration name: site_favicon
ds_docs  | WARNING  -  Config value 'dev_addr': The use of the IP address '0.0.0.0' suggests a production environment or the use of a proxy to connect to the MkDocs server. However, the MkDocs' server is intended for local development purposes only. Please use a third party production-ready server instead.
ds_docs  | INFO     -  Building documentation...
ds_docs  | INFO     -  Cleaning site directory
ds_docs  | WARNING  -  Both index.md and README.md found. Skipping README.md from /docs/docs/usecases
ds_docs  | INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
ds_docs  |   - recon.md
ds_docs  |   - redirect.md
ds_docs  |   - analysis/hvsrweb.md
ds_docs  |   - analysis/matlab.md
ds_docs  |   - analysis/overview.md
ds_docs  |   - analysis/swbatch.md
ds_docs  |   - css/README.md
ds_docs  |   - curating/index.md
ds_docs  |   - dictionary/experimental.md
ds_docs  |   - dictionary/field.md
ds_docs  |   - dictionary/hybrid.md
ds_docs  |   - dictionary/other.md
ds_docs  |   - dictionary/simulation.md
ds_docs  |   - js/README.md
ds_docs  |   - managingdata/index.md
ds_docs  |   - tools/simulation.md
ds_docs  |   - tools/hazard/hazardapps.md
ds_docs  |   - tools/hazard/jupyter-dedm.md
ds_docs  |   - tools/hazard/utilities.md
ds_docs  |   - tools/jupyterhub/examplenotebooks.md
ds_docs  |   - tools/jupyterhub/jupyterhub.md
ds_docs  |   - tools/jupyterhub/jupyterlabhpc.md
ds_docs  |   - tools/jupyterhub/jupytersomething.md
ds_docs  |   - tools/jupyterhub/publishingnotebooks.md
ds_docs  |   - tools/simulation/opensees.md
ds_docs  |   - tools/simulation/adcirc/adcirc_cli.md
ds_docs  |   - tools/simulation/adcirc/installation.md
ds_docs  |   - tools/simulation/adcirc/examples/examples.md
ds_docs  |   - tools/simulation/adcirc/examples/quarter_annular_harbor.md
ds_docs  |   - tools/simulation/adcirc/examples/shinnecock.md
ds_docs  |   - tools/simulation/adcirc/inputs/fort_14.md
ds_docs  |   - tools/simulation/adcirc/inputs/fort_15.md
ds_docs  |   - tools/simulation/adcirc/inputs/inputs.md
ds_docs  |   - tools/simulation/adcirc/outputs/outputs.md
ds_docs  |   - tools/simulation/opensees/OSApplications.md
ds_docs  |   - tools/simulation/opensees/OSDesignSafe.md
ds_docs  |   - tools/simulation/opensees/OSPlatforms.md
ds_docs  |   - tools/simulation/opensees/openseesApplications.md
ds_docs  |   - tools/simulation/opensees/openseesApplicationsNotes.md
ds_docs  |   - tools/simulation/opensees/openseesDecisionMatrixApplication.md
ds_docs  |   - tools/simulation/opensees/openseesDecisionMatrixPlatform.md
ds_docs  |   - tools/simulation/opensees/openseesDesignSafeQuickStart.md
ds_docs  |   - tools/simulation/opensees/openseesExpress.md
ds_docs  |   - tools/simulation/opensees/openseesHardware.md
ds_docs  |   - tools/simulation/opensees/openseesMP.md
ds_docs  |   - tools/simulation/opensees/openseesOverview.md
ds_docs  |   - tools/simulation/opensees/openseesProjectSize.md
ds_docs  |   - tools/simulation/opensees/openseesPy.md
ds_docs  |   - tools/simulation/opensees/openseesResources.md
ds_docs  |   - tools/simulation/opensees/openseesRunJupyterHPC.md
ds_docs  |   - tools/simulation/opensees/openseesRunJupyterPy.md
ds_docs  |   - tools/simulation/opensees/openseesRunLinux.md
ds_docs  |   - tools/simulation/opensees/openseesRunTACC.md
ds_docs  |   - tools/simulation/opensees/openseesRunVM.md
ds_docs  |   - tools/simulation/opensees/openseesRunVM_Specs.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal_Form.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal_Specs.md
ds_docs  |   - tools/simulation/opensees/openseesRunning.md
ds_docs  |   - tools/simulation/opensees/openseesSP.md
ds_docs  |   - tools/simulation/openseesOld/openseesOverview.md
ds_docs  |   - tools/simulation/openseesOld/openseesResources.md
ds_docs  |   - tools/simulation/openseesOld/openseesSubmitJob.md
ds_docs  |   - tools/simulation/openseesOld/openseesTutorial.md
ds_docs  |   - tools/visualization/figuregen.md
ds_docs  |   - tools/visualization/hazmapper.md
ds_docs  |   - tools/visualization/kalpana.md
ds_docs  |   - tools/visualization/overview.md
ds_docs  |   - tools/visualization/paraview.md
ds_docs  |   - tools/visualization/potree-converter.md
ds_docs  |   - tools/visualization/potree-viewer.md
ds_docs  |   - tools/visualization/qgis.md
ds_docs  |   - tools/visualization/stko.md
ds_docs  |   - tools/visualization/visit.md
ds_docs  |   - usecases/index.md
ds_docs  |   - usecases/apiusecases.md
ds_docs  |   - usecases/dataanalyticsusecases.md
ds_docs  |   - usecases/geohazardusecases.md
ds_docs  |   - usecases/seismicusecases.md
ds_docs  |   - usecases/windstormsurgeusecases.md
ds_docs  |   - usecases/arduino/usecase_matlab.md
ds_docs  |   - usecases/arduino/usecase_quoFEM.md
ds_docs  |   - usecases/arduino/usecase_siteResponse.md
ds_docs  |   - usecases/brandenberg-api/license.md
ds_docs  |   - usecases/usgs_api/usecase.md
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/data.png' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/geo.png' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/seismic.jpg' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/wind.png' which is not found in the documentation files.
ds_docs  | INFO     -  Documentation built in 14.28 seconds
ds_docs  | INFO     -  [20:23:24] Watching paths for changes: 'docs', 'mkdocs.yml', 'themes/tacc-readthedocs', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/themes/readthedocs', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/templates', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/contrib/search/templates', 'docs/analysis/hvsrweb.md', 'docs/analysis/matlab.md', 'docs/analysis/swbatch.md', 'docs/dictionary/experimental.md', 'docs/dictionary/simulation.md', 'docs/dictionary/hybrid.md', 'docs/dictionary/field.md', 'docs/dictionary/other.md', 'docs/redirect.md', 'docs/tools/hazard/hazardapps.md', 'docs/tools/hazard/jupyter-dedm.md', 'docs/tools/hazard/utilities.md', 'docs/tools/jupyterhub/jupyterhub.md', 'docs/tools/jupyterhub/jupyterlabhpc.md', 'docs/tools/jupyterhub/examplenotebooks.md', 'docs/tools/jupyterhub/publishingnotebooks.md', 'docs/tools/simulation/overview.md', 'docs/tools/simulation/adcirc/adcirc.md', 'docs/tools/simulation/adcirc/adcirc_cli.md', 'docs/tools/simulation/adcirc/inputs/inputs.md', 'docs/tools/simulation/adcirc/outputs/outputs.md', 'docs/tools/simulation/adcirc/examples/examples.md', 'docs/tools/simulation/adcirc/examples/quarter_annular_harbor.md', 'docs/tools/simulation/adcirc/examples/shinnecock.md', 'docs/tools/simulation/adcirc/installation.md', 'docs/tools/simulation/clawpack.md', 'docs/tools/simulation/dakota.md', 'docs/tools/simulation/in-core.md', 'docs/tools/simulation/lsdyna.md', 'docs/tools/simulation/openfoam.md', 'docs/tools/simulation/opensees.md', 'docs/tools/visualization/figuregen.md', 'docs/tools/visualization/hazmapper.md', 'docs/tools/visualization/kalpana.md', 'docs/tools/visualization/paraview.md', 'docs/tools/visualization/potree-converter.md', 'docs/tools/visualization/potree-viewer.md', 'docs/tools/visualization/qgis.md', 'docs/tools/visualization/stko.md', 'docs/usecases/haan/usecase.md', 'docs/usecases/haan/usecase-2.md', 'docs/tools/visualization/visit.md', 'docs/tools/simulation/opensees/openseesDesignSafeQuickStart.md', 'docs/usecases/vantassel_and_zhang/usecase.md', 'docs/usecases/padgett/usecase_JN_viz.md', 'docs/usecases/brandenberg-ngl/usecase.md', 'docs/usecases/kumar/usecase.md', 'docs/usecases/dawson/usecase.md', 'docs/usecases/dawson/usecase2.md', 'docs/usecases/padgett/usecase.md', 'docs/usecases/kareem/usecase.md', 'docs/usecases/pinelli/usecase.md', 'docs/usecases/arduino/usecase.md', 'docs/usecases/lowes/usecase.md', 'docs/usecases/rathje/usecase.md', 'docs/usecases/mosqueda/usecase.md', 'docs/usecases/brandenberg-api/usecase.md', 'docs/usecases/haan/usecase-3.md', 'docs/usecases/mosqueda/erler-mosqueda.md', 'docs/usecases/pinelli/2usecase.md', 'docs/usecases/kareem/usecase2.md', 'docs/usecases/kareem/usecase3.md'
ds_docs  | INFO     -  [20:23:24] Serving on http://0.0.0.0:8000/user-guide/
```

</details>

<img width="845" alt="ds-user-guide-91" src="https://github.com/user-attachments/assets/45b86b7b-4839-4e54-88d9-387c40fb7c04">
