### PR TITLE
docs: remove outdated use case from usecases.index

### DIFF
--- a/user-guide/docs/usecases/index.md
+++ b/user-guide/docs/usecases/index.md
@@ -10,10 +10,6 @@ To help users fully embrace DesignSafe functionalities, we have developed a suit
 * [**Machine Learning and AI Resources**](#ml-and-ai) (Jupyter, Interactive Data Analytics, HPC)
 * [**Visualization of spatially distributed data for risk and resilience analysis**](#visualization-of-spatially-distributed-data) (Jupyter, Interactive Data Visualization)
 
-### Taggit - Image Tagging
-
-{% include-markdown 'haan/usecase.md' %}
-
 ### ML and AI
 
 {% include-markdown 'vantassel_and_zhang/usecase.md' %}


### PR DESCRIPTION
## Overview

Remove Haan use case from Use Cases index doc.

## Related

- continues #100

## Testing

1. Load https://localhost:8000/user-guide/usecases/.
2. Verify no "Taggit" content.

## UI

<img width="960" alt="PR 102" src="https://github.com/user-attachments/assets/7f79abc8-f5a7-4147-894a-883eaaf6b2e6" />
