### PR TITLE
fix: exclude redundant search results

### DIFF
--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -30,6 +30,8 @@ extra_css:
 
 plugins:
   - search
+  - exclude-search:
+      exclude_unreferenced: true
   - include-markdown
 
 nav:


### PR DESCRIPTION
## Overview

Exclude redundant items from search.

<details><summary>Problem This Change Solves</summary>

Search normally shows results for content from all pages. But this repo includes pages (via [include-markdown](https://github.com/mondeja/mkdocs-include-markdown-plugin)) into other pages. So when user searches "A", which is on page "X", which is included on page "Y"; then search results show page "X" and page "Y". In this repository, page "X" is usually not in the navigation, while page "Y" is. So, visiting page "X" from search results shows a page with no relevant navigation revealed.

</details>
<details><summary>How This Change Solves It</summary>

This change excludes all content from search that are on pages that are not directly included by navigation i.e. it excludes and pages included via [include-markdown](https://github.com/mondeja/mkdocs-include-markdown-plugin) e.g. page "X" (an example described in "Problem This Change Solves").

</details>

## Related

- mimics https://github.com/TACC/TACC-Docs/pull/62

## Changed

- **added** a setting

## Testing

1. Search for a phrase that is in the docs on a page that is included in another page.
2. See zero duplicate results.

## UI

https://github.com/user-attachments/assets/7e0a7254-7440-434f-9756-44b4b606ca14

_The repeat headings in the results also have the **same** context; notice the smaller text underneath each duplicate heading._

https://github.com/user-attachments/assets/0276c2ff-2302-4fe8-a937-7b341dd48c5c

_The two "Description" results shown are from **different** context; notice the smaller text underneath each "Description"._