### PR TITLE
enhance: source of truth for mathjax

### DIFF
--- a/user-guide/docs/mathjax.md
+++ b/user-guide/docs/mathjax.md
@@ -1,0 +1,26 @@
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+    jax: ["input/TeX", "output/HTML-CSS"],
+    extensions: ["tex2jax.js"],
+    "HTML-CSS": {
+        preferredFont: "TeX",
+        availableFonts: ["STIX","TeX"]
+    },
+    tex2jax: {
+        inlineMath: [ ["$", "$"], ["\\(","\\)"] ],
+        displayMath: [ ["$$","$$"], ["\\[", "\\]"] ],
+        processEscapes: true, ignoreClass: "tex2jax_ignore|dno"
+    },
+    TeX: {
+        noUndefined: {
+            attributes: {
+            mathcolor: "red",
+            mathbackground: "#FFEEEE",
+            mathsize: "90%"
+            }
+        }
+    },
+    messageStyle: "none"
+});
+</script> 
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>

--- a/user-guide/docs/usecases/padgett/usecase_JN_viz.md
+++ b/user-guide/docs/usecases/padgett/usecase_JN_viz.md
@@ -13,18 +13,7 @@ _Keywords: visualization; risk and resilience; infrastructure systems; static, i
 
 ### Resources
 
-<script type="text/x-mathjax-config">
-MathJax.Hub.Config({  
-jax: ["input/TeX", "output/HTML-CSS"],
-extensions: ["tex2jax.js"],
-"HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"] },
-tex2jax: { inlineMath: [ ["$", "$"], ["\\(","\\)"] ], displayMath: [ ["$$","$$"], ["\\[", "\\]"] ], processEscapes: true, ignoreClass: "tex2jax_ignore|dno" }, 
-TeX: { noUndefined: { attributes: { mathcolor: "red", mathbackground: "#FFEEEE", mathsize: "90%" } } },
-messageStyle: "none"  
-});
-
-</script> 
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
+{% include-markdown '../../mathjax.md' %}
 
 #### Jupyter Notebooks
 The following Jupyter notebook is the basis for the use case described in this section. You can access and run it directly on DesignSafe by clicking on the "Open in DesignSafe" button.


### PR DESCRIPTION
## Overview

Move MathJax activation to a source of truth.

## Related

- fixes #44

## Testing

0. Open http://0.0.0.0:8000/user-guide/usecases/padgett/usecase_JN_viz/#Title2
1. Verify the math (see UI) is rendered as math, not "$…$".

## UI

| before math | with math one-off | with math source of truth |
| - | - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/4fa6caac-8df3-4722-bf59-cd909161c98b" /> | <img width="960" alt="current" src="https://github.com/user-attachments/assets/880232ef-5e94-4f1e-8ebb-8c3c059a8b21" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/db040613-ef58-4cb1-92bc-73736e2cec20" /> |

## Notes

This is a **short-term** solution for #44. A **middle-term** solution is [to update config in TACC/TACC-Docs](https://github.com/DesignSafe-CI/DS-User-Guide/issues/44#issuecomment-2173971202). The [long-term](https://github.com/DesignSafe-CI/DS-User-Guide/issues/44#issuecomment-2173971202) solution is **not** use Docker to get TACC skin (#42), so that DS-User-Guide can update is MkDocs config without worrying about skin.