### PR TITLE
enhance: clone TACC/TACC-Docs files directly

### DIFF
--- a/bin/tacc-setup.sh
+++ b/bin/tacc-setup.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# To provide files via a CDN from a specific repo at a specific commit-ish
-# https://github.com/DesignSafe-CI/DS-User-Guide/pull/14
-BASE_URL="https://cdn.jsdelivr.net/gh/DesignSafe-CI/DS-User-Guide@624d01be"
+# To provide files via a CDN from TACC at a specific commit
+BASE_URL="https://cdn.jsdelivr.net/gh/TACC/TACC-Docs@v0.15.1"
 
 # To avoid the error:
 # > ERROR - Config value 'theme': The path set in custom_dir
@@ -11,6 +10,6 @@ mkdir -p ./user-guide/themes/tacc-readthedocs
 
 # To clone TACC files (so authors can preview without Docker)
 # TODO: Make TACC/TACC-Docs public, so we can load from TACC/TACC-Docs via CDN
-curl -o ./user-guide/mkdocs.base.yml ${BASE_URL}/user-guide/mkdocs.base.yml
+curl -o ./user-guide/mkdocs.base.yml ${BASE_URL}/mkdocs.base.yml
 curl -o ./poetry.lock ${BASE_URL}/poetry.lock
 curl -o ./pyproject.toml ${BASE_URL}/pyproject.toml


### PR DESCRIPTION
### Overview

Clone [TACC/TACC-Docs](https://github.com/TACC/TACC-Docs) directly instead of from a protected utility branch.

### Related

- closes #14

### Testing

1. From root of repo, run
    ```sh
    rm ./{pyproject.toml,poetry.lock,user-guide/mkdocs.base.yml}
    ./bin/tacc-setup.sh
    ```
2. Verify no errors.
3. Verify `./pyproject.toml` has `tacc-docs` version `0.15.1`
4. Verify `./poetry.lock` has `babel`.
5. Verify `./user-guide/mkdocs.base.yml` exists.