### PR TITLE
fix: tacc-setup.sh cloning files to wrong dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ How to Contribute **Other Changes**:
     <sup>Known supported versions are [from 3.10 to 3.12](https://github.com/TACC/TACC-Docs/blob/v0.10.1/pyproject.toml#L9).</sup>
 1. [Install Poetry](https://python-poetry.org/docs/#installation) to manage dependencies.\
     <sup>You should only need to do this once.</sup>
-2. Navigate into `/user-guide/` within your clone of this repo.
+2. Navigate into `user-guide/` within your clone of this repo.
 3. Install/Update project dependencies:\
     <sup>You should only need to do this after new releases.</sup>
     ```shell

--- a/bin/tacc-setup.sh
+++ b/bin/tacc-setup.sh
@@ -11,5 +11,5 @@ mkdir -p ./user-guide/themes/tacc-readthedocs
 # To clone TACC files (so authors can preview without Docker)
 # TODO: Make TACC/TACC-Docs public, so we can load from TACC/TACC-Docs via CDN
 curl -o ./user-guide/mkdocs.base.yml ${BASE_URL}/mkdocs.base.yml
-curl -o ./poetry.lock ${BASE_URL}/poetry.lock
-curl -o ./pyproject.toml ${BASE_URL}/pyproject.toml
+curl -o ./user-guide/poetry.lock ${BASE_URL}/poetry.lock
+curl -o ./user-guide/pyproject.toml ${BASE_URL}/pyproject.toml


### PR DESCRIPTION
### Overview

Clone [TACC/TACC-Docs](https://github.com/TACC/TACC-Docs) poetry files into `/user-guide/ not root (like README expects).

### Related

- fixes #120

### Testing

1. From root of repo, run
    ```sh
    rm ./{pyproject.toml,poetry.lock,user-guide/mkdocs.base.yml}
    ./bin/tacc-setup.sh
    ```
2. Verify no errors.
3. Verify these files exist:
    - `./user-guide/pyproject.toml`
    - `./user-guide/poetry.lock`
    - `./user-guide/mkdocs.base.yml`