### PR TITLE
fix: GH-42 testing without docker uses diff theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ How to Contribute **Other Changes**:
 
 ### A. Via Python
 
-> [!IMPORTANT]
-> This method has different theme than [live website](https://designsafe-ci.org/user-guide/) ([#42](https://github.com/DesignSafe-CI/DS-User-Guide/issues/42)) **and** bugs ([#66](https://github.com/DesignSafe-CI/DS-User-Guide/issues/66)).
-
 0. Have [Python](https://www.python.org/) installed.\
     <sup>Known supported versions are [from 3.10 to 3.12](https://github.com/TACC/TACC-Docs/blob/v0.10.1/pyproject.toml#L9).</sup>
 1. [Install Poetry](https://python-poetry.org/docs/#installation) to manage dependencies.\

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ How to Contribute **Other Changes**:
     <sup>You should only need to do this after new releases.</sup>
     ```shell
     ../bin/tacc-setup.sh
-    poetry install
+    poetry install --sync
+
     ```
 4. Serve the docs:
     ```shell
     poetry shell
     mkdocs serve
+
     ```
     <sup>After the `poetry shell` command, you should be in a Poetry-managed environment. Your prompt might be prefixed with the name of the environment.</sup>
 5. Open the website _at the URL echoed by the program_ e.g.

--- a/bin/tacc-setup.sh
+++ b/bin/tacc-setup.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-# To provide files via a CDN from TACC at a specific commit
-BASE_URL="https://cdn.jsdelivr.net/gh/TACC/TACC-Docs@v0.15.1"
+# What version of TACC-Docs to use
+TACC_VER=v0.15.1
+# Where to get files from TACC
+BASE_URL="https://cdn.jsdelivr.net/gh/TACC/TACC-Docs@${TACC_VER}"
+# Get the directory where the script resides
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+# Create a temporary directory for the TACC docs
+TACC_DIR="${ROOT_DIR}/_temp-tacc-docs-for-ds"
 
-# To avoid the error:
-# > ERROR - Config value 'theme': The path set in custom_dir
-# >         ('.../user-guide/themes/tacc-readthedocs') does not exist.
-mkdir -p ./user-guide/themes/tacc-readthedocs
+# So authors can preview with TACC features but without Docker
+curl -o "${ROOT_DIR}/user-guide/mkdocs.base.yml" ${BASE_URL}/mkdocs.base.yml
+curl -o "${ROOT_DIR}/user-guide/poetry.lock" ${BASE_URL}/poetry.lock
+curl -o "${ROOT_DIR}/user-guide/pyproject.toml" ${BASE_URL}/pyproject.toml
 
-# To clone TACC files (so authors can preview without Docker)
-# TODO: Make TACC/TACC-Docs public, so we can load from TACC/TACC-Docs via CDN
-curl -o ./user-guide/mkdocs.base.yml ${BASE_URL}/mkdocs.base.yml
-curl -o ./poetry.lock ${BASE_URL}/poetry.lock
-curl -o ./pyproject.toml ${BASE_URL}/pyproject.toml
+# So authors can preview with TACC design but without Docker
+mkdir -p "${ROOT_DIR}/user-guide/themes/tacc-readthedocs"
+git clone -q --depth 1 --branch ${TACC_VER} https://github.com/TACC/TACC-Docs.git ${TACC_DIR}
+cp -r ${TACC_DIR}/themes/tacc-readthedocs "${ROOT_DIR}/user-guide/themes/"
+cp -r ${TACC_DIR}/docs/css/core "${ROOT_DIR}/user-guide/docs/css/"
+cp -r ${TACC_DIR}/docs/js/core "${ROOT_DIR}/user-guide/docs/js/"
+rm -rf ${TACC_DIR}


### PR DESCRIPTION
### Overview

Testing without Docker now uses same theme as TACC-Docs.

### Related

- closes #42
- closes #66
- closes #93

### Changes

- **changed** `bin/tacc-setup` script to work when run from anywhere
- **changed** `bin/tacc-setup` script to clone all theme and asset files
- **changed** `README` to not mention #42
- **changed** `README` to fix #93

### UI

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/f7e81e44-35ee-4daf-aecd-e3d2adcd0545" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/3aa2981f-43e7-444f-ad00-2f0f0c35644c" /> |