### PR TITLE
fix: edit link text wrong via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/tacc-docs:v0.12.0
+FROM taccwma/tacc-docs:v0.15.1
 
 # To archive TACC content, before replacing it
 RUN mv /docs /docs-from-tacc


### PR DESCRIPTION
## Overview

The new "Edit on GitHub" link was not "Suggest update via GitHub" via Docker, because DOcker's TACC-Docs image was not updated.

## Related

- fixes (in Docker) #90

## Changed

- updated TACC-Docs docker image

## Testing

0. Use docker.
1. Follow #90.

## UI

Same as #90.