### PR TITLE
docs: move adv stuff out of readme

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,12 @@
+# How to Develop
+
+Manage dependencies via [TACC/TACC-Docs](https://github.com/TACC/TACC-Docs). Serve docs via [MkDocs](https://www.mkdocs.org/). Test via [Docker](https://www.docker.com/). Deploys are [automated](./PUBLISHING.md).
+
+## Theming
+
+Customize MkDocs with [CSS, JS, ES, plugins, extensions](https://github.com/TACC/TACC-Docs/blob/v0.15.0/mkdocs.base.yml) and [theme overrides](https://github.com/TACC/TACC-Docs/tree/v0.15.0/themes/tacc-readthedocs) **from [TACC/TACC-Docs](https://github.com/TACC/TACC-Docs)** both via [script](./bin/tacc-setup.sh) and [via Docker](./Dockerfile).
+
+To theme another MkDocs project to look [like this](https://docs.tacc.utexas.edu/), please contact [@wesleyboar](https://www.github.com/wesleyboar).
+
+> [!NOTE]
+> We will eventually [use MkDocs Material](https://github.com/TACC/TACC-Docs/issues/53) and [apply TACC customization properly](https://github.com/TACC/TACC-Docs/issues/76).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Testing is manual and requires using a command prompt. You can test [via Python]
 
 We automatically publish `main` branch commits. We manually release versions of DS-User-Guide. [Read more](./PUBLISHING.md).
 
-## Theming
+## Developing
 
-To theme your documentation like this project, please contact [@wesleyboar](https://www.github.com/wesleyboar) or mimic [DS-User-Guide](https://github.com/DesignSafe-CI/DS-User-Guide/).
+We use [Poetry](https://python-poetry.org/), [Docker](https://www.docker.com/), [MkDocs](https://mkdocs.readthedocs.io/) and a customized theme. [Read more](./DEVELOPING.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,7 +29,7 @@
 
 ### B. Via Docker
 
-0. Have Docker installed.\
+0. Have [Docker](https://www.docker.com/) installed.\
     <sup>We recommend doing so via [Docker-Desktop](https://www.docker.com/products/docker-desktop).</sup>
 1. Navigate into your clone of this repository.
 2. Start the Docker container to serve the docs.


### PR DESCRIPTION
## Overview

Mimic [`TACC/TACC-Docs` effort to simplify README](https://github.com/TACC/TACC-Docs/pull/77).

## Related

- improves #123
- mimics https://github.com/TACC/TACC-Docs/pull/77

## Changes

- added `DEVELOPING.md`
- moved "Theming" overview to `DEVELOPING.md`
- added "Developing" overview to `README.md`
- changed `TESTING.md` to link to Docker

## Testing

1. Evaluate [`README.md`](https://github.com/DesignSafe-CI/DS-User-Guide/blob/docs/move-adv-stuff-out-of-readme/README.md).
    - Is it simpler?
    - Is advanced stuff out of the way.
 2. Evaluate [`DEVELOPING.md`](https://github.com/DesignSafe-CI/DS-User-Guide/blob/docs/move-adv-stuff-out-of-readme/DEVELOPING.md).
     - Is it simple?
     - Does dev know where to learn more?