### PR TITLE
Update mkdocs.yml remove 2 apps not in apps

### DIFF
--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -72,8 +72,8 @@ nav:
     - Overview: tools/simulation/overview.md
     - ADCIRC: tools/simulation/adcirc/adcirc.md
     - Ansys: tools/simulation/ansys.md
-    - ClawPack: tools/simulation/clawpack.md
-    - Dakota: tools/simulation/dakota.md
+    #- ClawPack: tools/simulation/clawpack.md
+    #- Dakota: tools/simulation/dakota.md
     - IN-CORE: tools/simulation/in-core.md
     - LS-DYNA: tools/simulation/lsdyna.md
     - OpenFoam: tools/simulation/openfoam.md


### PR DESCRIPTION
I have commented out Dakota and Clapack. They are no longer in the apps. But let's keep the content for now, in case they come back.

<!-- What did you change? -->

<!-- Do you want support (syntax, design, etc)? -->

<!-- Any reference material worth sharing? -->
