### PR TITLE
fix: force account-help ext links to open new tab

### DIFF
--- a/user-guide/docs/account-help.md
+++ b/user-guide/docs/account-help.md
@@ -2,12 +2,12 @@
 
 ## Password Reset
 
-To **reset your password**, go to [https://accounts.tacc.utexas.edu/forgot_password](https://accounts.tacc.utexas.edu/forgot_password), enter your username or email address that is associated with your user account, and you will receive an email with a password reset link. 
+To **reset your password**, go to [https://accounts.tacc.utexas.edu/forgot_password](https://accounts.tacc.utexas.edu/forgot_password){target="_blank"}, enter your username or email address that is associated with your user account, and you will receive an email with a password reset link. 
 
 ## Account Activation
 
-If you receive an **Authentication Failed** error when logging in, and you are confident that you have entered the correct password for your account, then it is likely that you need to **Reactivate Account** due to your account being Deactivated due to more than 120 days having passed since you last logged in. To reactivate your account, log in at accounts.tacc.utexas.edu and then request an activation link via [https://accounts.tacc.utexas.edu/activate](https://accounts.tacc.utexas.edu/activate). You will receive an email at the email address associated with your user account with instructions for account reactivation.
+If you receive an **Authentication Failed** error when logging in, and you are confident that you have entered the correct password for your account, then it is likely that you need to **Reactivate Account** due to your account being Deactivated due to more than 120 days having passed since you last logged in. To reactivate your account, log in at accounts.tacc.utexas.edu and then request an activation link via [https://accounts.tacc.utexas.edu/activate](https://accounts.tacc.utexas.edu/activate){target="_blank"}. You will receive an email at the email address associated with your user account with instructions for account reactivation.
 
 ## Additional Account Resources
 
-- [Managing Your TACC Account](https://docs.tacc.utexas.edu/basics/accounts/)
+- [Managing Your TACC Account](https://docs.tacc.utexas.edu/basics/accounts/){target="_blank"}


### PR DESCRIPTION
Changed "Account Help" page links[^1] to always open in new page.

_They have been opnening in new page only because of JavaScript._

[^1]: This change should be made to all external page links, and I thought I had got them all, but I guess not.