### PR TITLE
conf(.github): comment out cdelcastillo21 & parduino

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,11 +15,11 @@
 /user-guide/docs/tools/simulation/openseesOld/ @silviamazzoni
 
 # ADCIRC
-/user-guide/docs/tools/simulation/adcirc.md @cdelcastillo21
-/user-guide/docs/tools/simulation/adcirc/   @cdelcastillo21
+# /user-guide/docs/tools/simulation/adcirc.md @cdelcastillo21
+# /user-guide/docs/tools/simulation/adcirc/   @cdelcastillo21
 
 # Arduino
-/user-guide/docs/usecases/arduino/ @parduino
+# /user-guide/docs/usecases/arduino/ @parduino
 
 # static assets
 *.js  @wesleyboar


### PR DESCRIPTION
Comment out @cdelcastillo21 and @parduino ownership of files.

_These two users submit via fork. They are not direct collaborators (but they are welcome to become so, because access to this repo is well-managed now)._