### PR TITLE
chore: rename Applications to Apps in nav

### DIFF
--- a/user-guide/docs/index.md
+++ b/user-guide/docs/index.md
@@ -41,7 +41,7 @@ A DesignSafe account is a TACC user account, so you will sometimes see emails fr
 
 **Tools and Apps**: This section contains user guides for how to utilize our many offerings in data analytics, GIS and mapping, visualization, and our Jupyter Hub interacting with the data you bring to DesignSafe or that you discover in our Published datasets.
 
-**Simulation Applications**: We host a wide array of open source and licensed software applications commonly used in natural hazards research.
+**Simulation Apps**: We host a wide array of open source and licensed software applications commonly used in natural hazards research.
 
 **Use Cases**: To help users fully embrace DesignSafe functionalities, we have developed a suite of Use Cases that demonstrate how DesignSafe is being used to advance natural hazards research. Practical products, examples, and scripts developed as part of these Use Cases are provided at the links below. The different simulation codes, tools, and DesignSafe resources used in each Use Case are also indicated.
 

--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -65,13 +65,13 @@ nav:
       - Recon Portal User Guide: tools/recon.md
 
   - Tools and Apps:
-    - Analysis Applications: analysis.md
+    - Analysis Apps: analysis.md
     - Jupyter: tools/jupyterhub.md
     - Hazard Apps: tools/hazard.md
     - Utility Apps: tools/utilities.md
-    - Visualization Applications: tools/visualization.md
+    - Visualization Apps: tools/visualization.md
 
-  - Simulation Applications:
+  - Simulation Apps:
     - Overview: tools/simulation/overview.md
     - ADCIRC: tools/simulation/adcirc/adcirc.md
     - Ansys: tools/simulation/ansys.md


### PR DESCRIPTION
Renamed "Applications" to "Apps" in nav.

_For consistency. Also, stakeholders and a contributor and I have always agreed to reduce width of nav text when possible. The apps are called "Apps" in Tools & Apps page on main site. Let's call them Apps here._