### PR TITLE
refactor(usecases): overview, extract css & simplify html

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -73,6 +73,26 @@ b {
     font-weight: var(--bold);
 }
 
+/* To extend grid pattern (for pages like usecases/overview) */
+/* https://github.com/TACC/TACC-Docs/blob/v0.15.1/docs/css/core/tacc-docs.css#L521-L527 */
+/* https://github.com/TACC/mkdocs-tacc/blob/v0.6.0/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/core-docs.css#L52-L58 */
+.grid__header,
+.grid > :is(h1, h2, h3, h4, h5, h6) {
+    margin-block: 0;
+    grid-column: span 2;
+}
+/* To remove space from top of header-less intro paragraph in a grid */
+/* https://github.com/TACC/TACC-Docs/blob/f2e80b4/docs/index.md?plain=1#L107-L109 */
+/* https://github.com/DesignSafe-CI/DS-User-Guide/blob/92882f2/user-guide/docs/usecases/overview.md?plain=1#L21-L23 */
+.grid__header > p:first-child {
+    margin-top: 0;
+}
+/* To remove extra space under cards */
+.grid [class*="card"] {
+    margin-bottom: 0;
+}
+
+
 
 
 /* DS-DOCS */

--- a/user-guide/docs/usecases/overview.md
+++ b/user-guide/docs/usecases/overview.md
@@ -17,8 +17,7 @@ Make sure you are logged into DesignSafe so that you can access the Use-Case pro
 ////// html | img[alt="a data-driven map in a software interface"][src="./img/data.png"]
 //////
 
-Data Analytics
-{.h3}
+<h3>Data Analytics</h3>
 
 Analyze data from multiple datasets, with A.I. and Machine Learning, or via APIs or visualization.
 
@@ -29,8 +28,7 @@ Analyze data from multiple datasets, with A.I. and Machine Learning, or via APIs
 ////// html | img[alt="a color-coded landslide"][src="./img/geo.png"]
 //////
 
-GeoHazard
-{.h3}
+<h3>GeoHazard</h3>
 
 Geological hazard use cases like liquefaction and landslide modeling.
 
@@ -41,8 +39,7 @@ Geological hazard use cases like liquefaction and landslide modeling.
 ////// html | img[alt="a grid of two kinds of diagonal marks over 4 columns"][src="./img/seismic.jpg"]
 //////
 
-Seismic
-{.h3}
+<h3>Seismic</h3>
 
 Analyze seismic responses, soil structure interaction, and shake tables. Integrate with OpenSees.
 
@@ -53,8 +50,7 @@ Analyze seismic responses, soil structure interaction, and shake tables. Integra
 ////// html | img[alt="a triangular mesh over shallow water area of a coastal map"][src="./img/wind.png"]
 //////
 
-Wind and Storm Surge
-{.h3}
+<h3>Wind and Storm Surge</h3>
 
 Use cases for sensing wind, integrating hurricane data, using ADCIRC datasets or Jupyter Notebooks or QGIS.
 

--- a/user-guide/docs/usecases/overview.md
+++ b/user-guide/docs/usecases/overview.md
@@ -2,23 +2,9 @@
 
 DesignSafe provides a wide variety of resources that allow researchers to effectively share, find, analyze, and publish data; perform numerical simulations and utilize high performance computing (HPC); and integrate diverse datasets.
 
-<style>
-.grid {
-  display: grid;
-  gap: var(--global-space--grid-gap);
-  grid-template-columns: 1fr 1fr;
-}
-/* HACK: Remove space from top of section */
-/* NOTE: Not necessary if section head a header as is expected */
-/* https://github.com/TACC/TACC-Docs/blob/f2e80b4/docs/index.md?plain=1#L107-L109 */
-.grid > div[style] > p:first-child {
-  margin-top: 0;
-}
-</style>
-
 /// html | section.section--muted
 //// html | div.grid
-///// html | div[style="grid-column: span 2"]
+///// html | div.grid__header
 
 To help users fully embrace DesignSafe functionalities, we have developed a suite of Use Cases that demonstrate how DesignSafe is being used to advance natural hazards research.  Practical products, examples, and scripts developed as part of these Use Cases are provided for each Use Case.  The different simulation codes, tools, and DesignSafe resources used in each Use Case are also indicated.
 

--- a/user-guide/docs/usecases/overview.md
+++ b/user-guide/docs/usecases/overview.md
@@ -17,10 +17,8 @@ Make sure you are logged into DesignSafe so that you can access the Use-Case pro
 ////// html | img[alt="a data-driven map in a software interface"][src="./img/data.png"]
 //////
 
-<!-- To not use <h3> so this heading does not show in nav -->
-////// html | p.h3
 Data Analytics
-//////
+{.h3}
 
 Analyze data from multiple datasets, with A.I. and Machine Learning, or via APIs or visualization.
 
@@ -31,10 +29,8 @@ Analyze data from multiple datasets, with A.I. and Machine Learning, or via APIs
 ////// html | img[alt="a color-coded landslide"][src="./img/geo.png"]
 //////
 
-<!-- To not use <h3> so this heading does not show in nav -->
-////// html | p.h3
 GeoHazard
-//////
+{.h3}
 
 Geological hazard use cases like liquefaction and landslide modeling.
 
@@ -45,10 +41,8 @@ Geological hazard use cases like liquefaction and landslide modeling.
 ////// html | img[alt="a grid of two kinds of diagonal marks over 4 columns"][src="./img/seismic.jpg"]
 //////
 
-<!-- To not use <h3> so this heading does not show in nav -->
-////// html | p.h3
 Seismic
-//////
+{.h3}
 
 Analyze seismic responses, soil structure interaction, and shake tables. Integrate with OpenSees.
 
@@ -59,10 +53,8 @@ Analyze seismic responses, soil structure interaction, and shake tables. Integra
 ////// html | img[alt="a triangular mesh over shallow water area of a coastal map"][src="./img/wind.png"]
 //////
 
-<!-- To not use <h3> so this heading does not show in nav -->
-////// html | p.h3
 Wind and Storm Surge
-//////
+{.h3}
 
 Use cases for sensing wind, integrating hurricane data, using ADCIRC datasets or Jupyter Notebooks or QGIS.
 


### PR DESCRIPTION
Changes:
- moved css to stylesheet [^1]
- simplified level 3 headings to just use HTML [^2]

[^1]: Because #144 will use it also.
[^2]: An `<h3>` will not show in the navigation.