### PR TITLE
refactor(css): paragraph in a header

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -103,28 +103,43 @@ hr.spacer {
     margin-block: 20rem 5rem;
 }
 
-/* To both couple and distinguish short title and long title */
-.rst-content header p:is(#tacc-readthedocs *) {
+/* To make:
+    - short title (heading) less emphasized
+    - long heading (paragraph following heading) a long title that looks like a heading */
+/* (if using TACC theme) */
+.rst-content [itemprop="articleBody"]>[id^="tacc"] header h2 + p {
     font-size: var(--global-font-size--xx-large);
     font-weight: var(--bold);
 }
-.rst-content header h2:is(#tacc-readthedocs *) {
+.rst-content [itemprop="articleBody"]>[id^="tacc"] header h3 + p {
     font-size: var(--global-font-size--x-large);
-    font-weight: var(--regular);
-
-    /* To remove excess space between titles */
-    margin-bottom: -24px;
+    font-weight: var(--bold);
 }
-.rst-content header p:not(#tacc-readthedocs *) {
+.rst-content [itemprop="articleBody"]>[id^="tacc"] header :is(h2, h3) {
+    font-weight: var(--regular);
+    margin-bottom: -24px; /* to remove excess space between titles */
+}
+.rst-content [itemprop="articleBody"]>[id^="tacc"] header h2 {
+    font-size: var(--global-font-size--x-large);
+}
+.rst-content [itemprop="articleBody"]>[id^="tacc"] header h3 {
+    font-size: var(--global-font-size--large);
+}
+/* (not using TACC theme) - unnecessary after DesignSafe-CI/DS-User-Guide#155 */
+.rst-content [itemprop="articleBody"]>:not([id^="tacc"]) header h2 + p,
+.rst-content [itemprop="articleBody"]>:not([id^="tacc"]) header h3 + p {
     font-size: 150%;
     font-weight: 700;
 }
-.rst-content header h2:not(#tacc-readthedocs *) {
-    font-size: 16px;
+.rst-content [itemprop="articleBody"]>:not([id^="tacc"]) header :is(h2, h3) {
     font-weight: unset;
-
-    /* To remove excess space between titles */
-    margin-bottom: 0.5em;
+    margin-bottom: -24px; /* to remove excess space between titles */
+}
+.rst-content [itemprop="articleBody"]>:not([id^="tacc"]) header h2 {
+    font-size: 21px;
+}
+.rst-content [itemprop="articleBody"]>:not([id^="tacc"]) header h3 {
+    font-size: 16px;
 }
 
 /* To hide unused space at bottom of overview pages */


### PR DESCRIPTION
- Support `header h3 + p`.
    <sup>Before, only `header h2 + p` was supported.</sup>
- Prepare for `#tacc-readthedocs` → `#tacc_readthedocs` in v3.
