### PR TITLE
Update index.md

### DIFF
--- a/user-guide/docs/index.md
+++ b/user-guide/docs/index.md
@@ -36,7 +36,7 @@ A DesignSafe account is a TACC user account, so you will sometimes see emails fr
 
 ## Initial Onboarding
 
-When you are ready to begin uploading your own data to the Data Depot or want to begin using some of the Tools & Apps, you will want to initiate the onboarding process. The initial onboarding provides you with [private areas for your data](/user-guide/managingdata/datadepot/) and access to Tools & Apps that are hosted on our Virtual Machines such as [JupyterHub](https://www.designsafe-ci.org/use-designsafe/tools-applications/analysis/jupyter/) or [Interactive VM for OpenSees](https://www.designsafe-ci.org/use-designsafe/tools-applications/simulation/opensees/). Access to HPC-enabled applications requires [an additional step](#requestallocations).
+When you are ready to begin uploading your own data to the Data Depot or want to begin using some of the Tools & Apps, you will want to initiate the onboarding process. The initial onboarding provides you with [private areas for your data](/user-guide/managingdata/datadepot/) and access to Tools & Apps that are hosted on our Virtual Machines such as [JupyterHub](https://www.designsafe-ci.org/use-designsafe/tools-applications/analysis/jupyter/). Access to HPC-enabled applications requires [an additional step](#requestallocations).
 
 There are 2 ways to invoke the onboarding:
 


### PR DESCRIPTION
I was reviewing yesterday's changes in production this morning, and realized that in the Initial Onboarding section I had left the reference to Interactive VM for OpenSees. However, we have deprecated that offering so this edit is to remove that from the text and just have JupyterHub as the example of an app hosted via our virtual machines.
