### PR TITLE
fix: mistakes during "data depot" refactor

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -154,6 +154,25 @@ hr.spacer {
     font-size: 16px;
 }
 
+/* To add subtitle after headings */
+[data-subtitle]::after {
+    content: ' ' attr(data-subtitle);
+}
+[data-subtitle]:not(
+    /* headings only distinguished by weight */
+    h5, h6
+)::after {
+    font-weight: normal;
+}
+[data-subtitle]:is(
+    /* headings that need subtitle below */
+    h1
+)::after {
+    display: block;
+    text-transform: none;
+    font-size: var(--global-font-size--xx-large);
+}
+
 /* To hide unused space at bottom of overview pages */
 /* https://github.com/TACC/TACC-Docs/blob/a9d01e1/docs/css/core/tacc-docs.css#L568-L574 */
 [data-page-name$="usecases/overview.md"] footer {

--- a/user-guide/docs/curating/bestpractices.md
+++ b/user-guide/docs/curating/bestpractices.md
@@ -1,4 +1,4 @@
-# Best Practices for Data Curation and Publication 
+# Best Practices { data-subtitle="for Data Curation and Publication" }
 
 ## Curation Quality 
 

--- a/user-guide/docs/curating/guides.md
+++ b/user-guide/docs/curating/guides.md
@@ -1,4 +1,4 @@
-# How to Curate Data?
+# Guides: { data-subtitle="Steps to Curate and Publish your Datasets" }
 
 We offer step-by-step guides on how to create projects in the Data Depot, and curate and publish work/data across DesignSafe: [**Experimental**](#experimental), [**Simulation**](#simulation), [<del>**Hybrid Simulation**<del>](#hybrid), [**Field Research**](#fieldresearch), [**Other**](#other). For more information: [Policies](/user-guide/curating/policies), [Best Practices](/user-guide/curating/bestpractices/), [Frequently Asked Questions](/user-guide/curating/faq/).
 

--- a/user-guide/docs/curating/index.md
+++ b/user-guide/docs/curating/index.md
@@ -2,9 +2,10 @@
 
 {% include-markdown '../redirect.md' %}
 
-- [About the Data Depot](/user-guide/datadepotrepo/about/)
-- [Managing Your Data](/user-guide/managingdata/datadepot/)
-- [Setting Path to DesignSafe](/user-guide/managingdata/settingpathtodesignsafe/)
-- [Transferring Your Data](/user-guide/managingdata/datatransfer/)
-- [Data Management Plan](/user-guide/managingdata/datamanagementplan/)
-- [Experimental Facility Checklist](/user-guide/managingdata/experimentalfacilitychecklist)
+- [Guides: Steps to Curate and Publish your Datasets](/user-guide/curating/guides/)
+- [Best Practices for Data Curation and Publication ](/user-guide/curating/bestpractices.md)
+- [NHERI Virtual Office Hours](https://www.designsafe-ci.org/facilities/virtual-office-hours/)
+- [Metrics: Data Dissemination and Impact](/user-guide/curating/metrics.md)
+- [Frequently Asked Questions](/user-guide/curating/faq.md)
+- [Policies](/user-guide/curating/policies.md)
+- [Metadata Dictionaries](/user-guide/dictionary.md)

--- a/user-guide/docs/curating/index.md
+++ b/user-guide/docs/curating/index.md
@@ -1,0 +1,10 @@
+# Curating & Publishing Projects
+
+{% include-markdown '../redirect.md' %}
+
+- [About the Data Depot](/user-guide/datadepotrepo/about/)
+- [Managing Your Data](/user-guide/managingdata/datadepot/)
+- [Setting Path to DesignSafe](/user-guide/managingdata/settingpathtodesignsafe/)
+- [Transferring Your Data](/user-guide/managingdata/datatransfer/)
+- [Data Management Plan](/user-guide/managingdata/datamanagementplan/)
+- [Experimental Facility Checklist](/user-guide/managingdata/experimentalfacilitychecklist)

--- a/user-guide/docs/curating/metrics.md
+++ b/user-guide/docs/curating/metrics.md
@@ -1,4 +1,4 @@
-# Data Dissemination and Impact
+# Metrics { data-subtitle="Data Dissemination and Impact" }
 
 Data metrics indicate research impact, allowing researchers to assess the repercussions and influence of their work. Citation and usage metrics are included, and are visible on the landing page of each dataset publication. 
 

--- a/user-guide/docs/curating/metrics.md
+++ b/user-guide/docs/curating/metrics.md
@@ -1,4 +1,4 @@
-# Metrics { data-subtitle="Data Dissemination and Impact" }
+# Metrics: { data-subtitle="Data Dissemination and Impact" }
 
 Data metrics indicate research impact, allowing researchers to assess the repercussions and influence of their work. Citation and usage metrics are included, and are visible on the landing page of each dataset publication. 
 


### PR DESCRIPTION
<!-- What did you change? -->
- **fixes** missing old curating/index.md "redirect" page
- **adds** `[data-subtitle]` feature
- **fixes** titles & subititles to match old new content
- **updates** titles on curating/index redirect page
