### PR TITLE
refactor: move "DMP Guide" to "Resources"

### DIFF
--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
     - Transferring Your Data: managingdata/datatransfer.md
     - Managing Your Data:
       - Overview: managingdata/datadepot.md
-      - Data Management Plan (DMP) Guide: managingdata/datamanagementplan.md
     # WARNING: From here down, preserve URLs
     #          If URLs must change, add/use redirect plugin
     - Steps to Curate and Publish Your Datasets: curating/guides.md
@@ -57,6 +56,7 @@ nav:
     - Resources for Users:
       - Frequently Asked Questions: curating/faq.md
       - Curating Data in Experimental Facilities: managingdata/experimentalfacilitychecklist.md
+      - Data Management Plan (DMP) Guide: managingdata/datamanagementplan.md
     - About the Data Depot: datadepotrepo/about.md
     - Policies: curating/policies.md
 


### PR DESCRIPTION
<!-- What did you change? -->
Moved "Data Management Plan (DMP) Guide" to "Resources for Users".

<!-- Any reference material worth sharing? -->
Part of #175.