### PR TITLE
fix: GH-75 active nav link vs nav heading

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -237,3 +237,12 @@ dt {
 dd {
     margin-bottom: 1em;
 }
+
+/* To distinguish active item from heading */
+/* To highlight active item with more than just bold */
+/* https://github.com/TACC/TACC-Docs/blob/v0.15.1/docs/css/core/tacc-docs.css#L75-L104 */
+/* FAQ: Overrides TACC (which overrides ReadTheDocs) */
+/* TODO: Ask lead designer whether this is suitable for Mkdocs-TACC */
+.wy-menu-vertical li.current > a:not(:has(+ ul li.current)) {
+    background: #e3e3e3; /* copied from TACC's .wy-menu-vertical a:hover */
+}


### PR DESCRIPTION
<!-- What did you change? -->
Changed CSS to distinguish nav heading from active nav link. 

<!-- Do you want support (syntax, design, etc)? -->
I got direction and approval from H.P. for just DesignSafe.

<!-- Any reference material worth sharing? -->
<details><summary>Goal</summary>

| active | active + hover | selected vs. hover |
| - | - | - |
| <img width="381" height="280" alt="selected" src="https://github.com/user-attachments/assets/448ad5b1-b1d3-4aaf-b0a5-bc4ce32610b6" /> | <img width="381" height="280" alt="selected + hover" src="https://github.com/user-attachments/assets/038584fd-c69f-4bd4-8491-ca2e57cead1f" /> | <img width="381" height="280" alt="selected vs hover" src="https://github.com/user-attachments/assets/70535020-1d52-4ad4-b909-01dc8cf6e81e" /> |

</details>

<details open><summary>Result</summary>

https://github.com/user-attachments/assets/9f30d13e-fd73-4e72-ae7b-1f83c441e8a6

</details>