### PR TITLE
fix: training resources nav link location

### DIFF
--- a/.github/workflows/build-pprd.yml
+++ b/.github/workflows/build-pprd.yml
@@ -3,8 +3,7 @@ name: DS User Guide PPRD Builds
 on:
   push:
     branches:
-      - fix/GH-175-changes-set-3
-      - refactor/GH-175-tools-apps-nested-nav-items
+      - fix/training-resources-location-in-nav
 
 jobs:
   docker:

--- a/user-guide/mkdocs.yml
+++ b/user-guide/mkdocs.yml
@@ -40,9 +40,9 @@ nav:
   - DesignSafe Essentials:
     - Getting Started: index.md
     - Account Help: account-help.md
-    - Training Resources: training.md
     - DesignSafe FAQ: tools/advanced/dsfaq.md
     - How to Cite DesignSafe: how-to-cite.md
+    - Training Resources: training.md
 
   - DesignSafe Data Depot:
     - Overview: datadepot.md
@@ -60,7 +60,7 @@ nav:
     - Policies: curating/policies.md
 
   - Tools and Apps:
-    - Requesting New Applications: tools/overview.md
+    - Training Resources: training.md
     - Popular:
       - OpenSees: tools/simulation/opensees/opensees.md
       - ADCIRC: tools/simulation/adcirc/adcirc.md
@@ -89,6 +89,7 @@ nav:
     - Visualization: tools/visualization.md
     - Hazard Apps: tools/hazard.md
     - Utilities: tools/utilities.md
+    - Requesting New Applications: tools/overview.md
 
   - Recon Portal:
     - Recon Portal User Guide: tools/recon.md


### PR DESCRIPTION
"Training Resources" is not best location (Tools & Apps meeting decision). So, we:

- move to bottom of "DesignSafe Essentials"
- add to top of "Tools & Apps"
- move "Requesting New Applications" to bottom of Tools & Apps

https://github.com/user-attachments/assets/5b6bddc2-7b9b-4793-ab24-1fc0d8ded0f8