### PR TITLE
Task/wg 229 fix hazmapper user guide - simpler icon syntax

### DIFF
--- a/user-guide/docs/css/ds-docs.css
+++ b/user-guide/docs/css/ds-docs.css
@@ -108,6 +108,16 @@ b {
 
 
 
+/* TACC-DOCS via DS-DOCS */
+/* To add CSS that should be moved to TACC/TACC-Docs */
+
+/* To add space before and after icon from `_text_{ .fa fa.icon-name }` */
+.fa::before {
+    margin-inline: 0.5ch;
+}
+
+
+
 /* DS-DOCS */
 /* To add CSS unique to DesignSafe/DS-User-Guide */
 

--- a/user-guide/docs/tools/visualization/hazmapper.md
+++ b/user-guide/docs/tools/visualization/hazmapper.md
@@ -47,9 +47,9 @@ The header of the menu displays the name of the map and the DesignSafe project t
 
 On the rightmost side of the header is the ![plus icon](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/7.x/svgs/solid/plus.svg){: height="12" width="12" } _Create a New Map_ button, which opens the [map creation prompt](/user-guide/tools/visualization/hazmapper/#map-creation-prompt).
 
-The icons on the right side of each map item are _edit_ ![](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/7.x/svgs/solid/pen-to-square.svg){: height="12" width="12" } and _delete_ ![trash icon](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/7.x/svgs/solid/trash.svg){: height="12" width="12" }.
+The icons on the right side of each map item are _edit_{: .fa .fa-edit } and _delete_{: .fa .fa-trash }.
 
-To access a map, the user can either click on a map item or click on the _edit_ ![edit icon](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/7.x/svgs/solid/pen-to-square.svg){: height="12" width="12" } button. To delete a map, the user can click on the _delete_ ![trash icon](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/7.x/svgs/solid/trash.svg){: height="12" width="12" } button of a map.
+To access a map, the user can either click on a map item or click on the _edit_{: .fa .fa-edit } button. To delete a map, the user can click on the _delete_{: .fa .fa-trash } button of a map.
 
 ![](https://raw.githubusercontent.com/TACC-Cloud/hazmapper/hazmapper-documentation/docs/docs/img/menu.png){: class="align-center" width="70%" }
 


### PR DESCRIPTION
<!-- What did you change? -->
Simplify syntax of icons. Add CSS for space around icons.

<!-- Do you want support (syntax, design, etc)? -->
Notice icons are moved to `::before` the text. Is that okay?

<!-- Any reference material worth sharing? -->
| before | after |
| - | - |
| <img width="725" height="135" alt="before" src="https://github.com/user-attachments/assets/c5fbd71d-63cf-4443-a5cb-a8adc561d6e7" /> | <img width="725" height="135" alt="after" src="https://github.com/user-attachments/assets/5f85c9e1-5fda-47f9-9c8c-449eb4f9c5d5" /> |

Icon class is from built-in [FontAwesome v4 and `edit` alias for `pencil-square-o`](https://fontawesome.com/v4/icon/pencil-square-o).[^1]

[^1]: I will likely update to v7. Designers seem to agree on returning to Font Awesome (because it has so many more icons now, and now supports custom icons).