### PR TITLE
Task/wg 229 fix hazmapper user guide - use admonition, not card

### DIFF
--- a/user-guide/docs/tools/visualization/hazmapper.md
+++ b/user-guide/docs/tools/visualization/hazmapper.md
@@ -69,14 +69,10 @@ Once the user selects the name and description, unless manually specified, the m
 
 Next, by browsing through the file browser, the user can select a location in the DesignSafe Data Depot the map will be saved to.
 
-/// html | article.card--plain
-    markdown: block
+!!! note
+    By saving the map into the correct DesignSafe project folder, Hazmapper automatically associates the map with that project. This ensures that once the project is published, the DesignSafe Published Project page can link directly to your Hazmapper map, providing a curated, interactive geospatial view of your data for the public.
 
-By saving the map into the correct DesignSafe project folder, Hazmapper automatically associates the map with that project. This ensures that once the project is published, the DesignSafe Published Project page can link directly to your Hazmapper map, providing a curated, interactive geospatial view of your data for the public.
-
-_See [Public Hazmapper Maps and DesignSafe Published Projects](/user-guide/tools/visualization/hazmapper/#public-maps-published-projects) for more information._
-
-///
+    _See [Public Hazmapper Maps and DesignSafe Published Projects](/user-guide/tools/visualization/hazmapper/#public-maps-published-projects) for more information._
 
 For clarity, the selected location will be displayed in the _Save Location_ section.
 


### PR DESCRIPTION
<!-- What did you change? -->
Used Admonition syntax instead of `.card` custom HTML (via markdown).

<!-- Do you want support (syntax, design, etc)? -->
I think this is more appropriate, semantically, because this content is a note. The card is used for custom display of cards, but here is being re-purposed in favor of an existing tool.

<!-- Any reference material worth sharing? -->
| before | after |
| - | - |
| <img width="1024" height="465" alt="before" src="https://github.com/user-attachments/assets/032ac710-9a18-4ba4-8dfa-543d327d9d1b" /> | <img width="1024" height="465" alt="after" src="https://github.com/user-attachments/assets/e33512b5-613e-4f85-b88b-6be54a9e7d4a" /> |

I might have used the [PyMdownX syntax for admonitions](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/admonition/), but that one cannot be active with [Python-Markdown syntax](https://python-markdown.github.io/extensions/admonition/).

These features are documented on [MkDocs-TACC > Extensions](https://tacc.github.io/mkdocs-tacc/extensions/#demos).