### PR TITLE
fix: docs_dir not set

### DIFF
--- a/.github/workflows/build-pprd.yml
+++ b/.github/workflows/build-pprd.yml
@@ -6,7 +6,7 @@ on:
       - pprd
       - epic/v3
       - any/branch-you-want
-      - refactor/gh-158-proper-theme
+      - fix/docs_dir-not-set
 
 jobs:
   docker:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: DesignSafe User Guide
 site_url: https://designsafe-ci.org/user-guide/
 repo_url: https://github.com/DesignSafe-CI/DS-User-Guide
 edit_uri: edit/main/user-guide/
+docs_dir: user-guide
 # NOTE: Unrecognized by MkDocs, but recognized by ReadTheDocs theme
 site_favicon: https://www.designsafe-ci.org/favicon.ico
 


### PR DESCRIPTION
<!-- What did you change? -->
Add missing `docs_dir` to support non-standard `/user-guide`.

Tested via https://github.com/DesignSafe-CI/DS-User-Guide/actions/runs/20077164245/job/57594507517 success and https://pprd.designsafe-ci.org/user-guide/ accessible soon after.