### PR TITLE
fix: better title for "Subsequent Publishing"

### DIFF
--- a/user-guide/curating/policies.md
+++ b/user-guide/curating/policies.md
@@ -588,7 +588,7 @@ What does not qualify as research software:
 * Minor 'utility' packages, including 'thin' API clients, and single-function packages are not research software.
 * Exploratory visualizations or basic scripting tools to analyze data are not considered research software. These can be published along with their respective datasets.
 
-## Subsequent Publishing
+## Publishing Additional Datasets
 
 DDR enables publishing datasets subsequently within a project, and each dataset will bear a unique citation and DOI. This feature is necessary due to the timing of research projects involving multiple experiments,  simulations, and field research missions which happen over time. These datasets may involve different teams, and require the publication of different documents or datasets at different time intervals.
 


### PR DESCRIPTION
## What did you change?

_On behalf of @mesteva:_

Change "Subsequent Publishing" to "Publishing Additional Datasets".

## Do you want support (syntax, design, etc)?

1. ~~Do I need to keep the old heading link `#subsequent-publishing`?~~[^1]
    - Otherwise, new heading link is used, `#publishing-additional-datasets`.
    - I can support both.

## Any reference material worth sharing?

https://deploy-preview-249--ds-user-guide.netlify.app/curating/policies/#publishing-additional-datasets

[^1]: Question is too technical for the author, so I do not ask. I do not support old heading, and will add support if issue is reported, and take responsibility for it not having been retained.