### PR TITLE
fix: docker build since v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
       - .:/docs
     ports:
       - 127.0.0.1:8000:8000
-    command: ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8000", "--watch-theme", "--config-file", "/user-guide/mkdocs.yml"]
+    command: ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8000", "--watch-theme", "--config-file", "/docs/mkdocs.yml"]
     container_name: designsafe_user_guide


### PR DESCRIPTION
## What Did You Change?

Bad path in `docker-compose.yml`. Caused `make start` fail (and docker build fail).
