### PR TITLE
fix: remove "OpenSees on DesignSafe" (broken link)

### DIFF
--- a/user-guide/training.md
+++ b/user-guide/training.md
@@ -4,14 +4,6 @@ DesignSafe-CI offers a suite of training resources aimed at equipping researcher
 
 <section class="section--light">
     <div class="grid">
-        <a class="card--plain" href="https://DesignSafe-CI.github.io/training-OpenSees-on-DesignSafe" target="_blank">
-            <h3>
-OpenSees on DesignSafe
-            </h3>
-            <p>
-Learn to use OpenSees to develop, run, and scale structural & geotechnical simulations on DesignSafe/TACC. This hands-on module covers managing input files, launching parameter studies, and submitting and monitoring HPC jobs for reproducible workflows.
-            </p>
-        </a>
         <a class="card--plain" href="https://DesignSafe-CI.github.io/training-database-api" target="_blank">
             <h3>
 Database API training


### PR DESCRIPTION
## What Did You Change?

Deleted link to "OpenSees on DesignSafe" training, because link is broken and it will be consolidated/merged into DAPI training resources.


## Do You Want Support (syntax, design, etc)?

No; this is coming from stakeholders, who are actively reviewing training content and will integrate the training into a different form.

<!-- After you open this PR, you can preview your changes. A comment will appear with a link to the server. -->

## Any Reference Material Worth Sharing?

[Internal request.](https://tacc-team.slack.com/archives/C0AABGCGV4N/p1775150621856409)