### PR TITLE
fix: ext icon in breadcrumb is missing margin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -266,14 +266,14 @@ cache = ["platformdirs"]
 
 [[package]]
 name = "mkdocs-tacc"
-version = "1.0.3"
+version = "1.0.4"
 description = "TACC-specific MkDocs theme"
 optional = false
 python-versions = "<3.13,>=3.10"
 groups = ["main"]
 files = [
-    {file = "mkdocs_tacc-1.0.3-py3-none-any.whl", hash = "sha256:35d293c93220bce94127d718400c8ec6218379fd0d27cffcc1cd15921db1b06c"},
-    {file = "mkdocs_tacc-1.0.3.tar.gz", hash = "sha256:fc02f5fb94dc3cf4e29ddf60009ee5a131a8b733480cebfbb028d51dde7c6727"},
+    {file = "mkdocs_tacc-1.0.4-py3-none-any.whl", hash = "sha256:1029eafd35b9996e19fb560aae9d1174d4262e1e3a3c3c5ed3518f7d5cd0a16a"},
+    {file = "mkdocs_tacc-1.0.4.tar.gz", hash = "sha256:9945a00aeb67ca27609d7a15e63e6495fe4bc404af1ac8ac4731507a814470db"},
 ]
 
 [package.dependencies]
@@ -490,4 +490,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "f7f414d5fdd19c237a2767d5081676f11a05820d5d075f99aa8a27ccd79d3c6a"
+content-hash = "2a74ac71807eeda0d921aa985de7c7e25ca34ff184fb34822adff68e04f8d8fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-  "mkdocs-tacc[all] (>=1.0.0,<2.0.0)",
+  "mkdocs-tacc[all] (>=1.0.4,<2.0.0)",
   "mkdocs-exclude-search (>=0.6.6,<0.7.0)",
   "mkdocs-include-markdown-plugin (>=5.1.0,<6.0.0)",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,9 +115,9 @@ mkdocs-exclude-search==0.6.6 ; python_version >= "3.10" and python_version < "3.
 mkdocs-include-markdown-plugin==5.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4a1b8d79a0e1b6fd357ca8013a6d1701c755ada4acb74ee97b0642d1afe6756e \
     --hash=sha256:e9ca188ab1d86f5fc4a6b96ce8c85acf6e25f114897868041056ec7945f29f65
-mkdocs-tacc==1.0.3 ; python_version >= "3.10" and python_version < "3.13" \
-    --hash=sha256:35d293c93220bce94127d718400c8ec6218379fd0d27cffcc1cd15921db1b06c \
-    --hash=sha256:fc02f5fb94dc3cf4e29ddf60009ee5a131a8b733480cebfbb028d51dde7c6727
+mkdocs-tacc==1.0.4 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:1029eafd35b9996e19fb560aae9d1174d4262e1e3a3c3c5ed3518f7d5cd0a16a \
+    --hash=sha256:9945a00aeb67ca27609d7a15e63e6495fe4bc404af1ac8ac4731507a814470db
 mkdocs==1.4.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5955093bbd4dd2e9403c5afaf57324ad8b04f16886512a3ee6ef828956481c57 \
     --hash=sha256:6ee46d309bda331aac915cd24aab882c179a933bd9e77b80ce7d2eaaa3f689dd

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,9 +115,9 @@ mkdocs-exclude-search==0.6.6 ; python_version >= "3.10" and python_version < "3.
 mkdocs-include-markdown-plugin==5.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4a1b8d79a0e1b6fd357ca8013a6d1701c755ada4acb74ee97b0642d1afe6756e \
     --hash=sha256:e9ca188ab1d86f5fc4a6b96ce8c85acf6e25f114897868041056ec7945f29f65
-mkdocs-tacc==1.0.4 ; python_version >= "3.10" and python_version < "3.13" \
-    --hash=sha256:1029eafd35b9996e19fb560aae9d1174d4262e1e3a3c3c5ed3518f7d5cd0a16a \
-    --hash=sha256:9945a00aeb67ca27609d7a15e63e6495fe4bc404af1ac8ac4731507a814470db
+mkdocs-tacc==1.0.3 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:35d293c93220bce94127d718400c8ec6218379fd0d27cffcc1cd15921db1b06c \
+    --hash=sha256:fc02f5fb94dc3cf4e29ddf60009ee5a131a8b733480cebfbb028d51dde7c6727
 mkdocs==1.4.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5955093bbd4dd2e9403c5afaf57324ad8b04f16886512a3ee6ef828956481c57 \
     --hash=sha256:6ee46d309bda331aac915cd24aab882c179a933bd9e77b80ce7d2eaaa3f689dd


### PR DESCRIPTION
## What Did You Change?

Updated `mkdocs-tacc` to latest.

## Do You Want Support (syntax, design, etc)?

Nah. Tested upstream with [mkdocs-tacc@v1.0.4](https://github.com/TACC/mkdocs-tacc/releases/tag/v1.0.4).

| before | after |
| - | - |
| <img width="192" height="43" alt="before" src="https://github.com/user-attachments/assets/6cb4af93-f3f5-426c-987c-dd1e80a4a32f" /> | <img width="192" height="43" alt="after" src="https://github.com/user-attachments/assets/fd08215a-53de-4811-869c-092bb4d82ac5" /> |

## Any Reference Material Worth Sharing?

Fixed upstream with [mkdocs-tacc@v1.0.4](https://github.com/TACC/mkdocs-tacc/releases/tag/v1.0.4).