### PR TITLE
fix: remove Taggit from user guide navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,8 +111,6 @@ nav:
     - GIS Tools:
       - Hazmapper: tools/visualization/hazmapper.md
       - QGIS: tools/visualization/qgis.md
-      - "Taggit: Basic Image Browsing and Mapping": tools/visualization/taggit-browse-map.md
-      - "Taggit: Grouping and Tagging Image Files": tools/visualization/taggit-categorize.md
     - Visualization: tools/visualization.md
     - Hazard Apps: tools/hazard.md
     - Utilities: tools/utilities.md
@@ -150,7 +148,6 @@ nav:
   - Use Cases:
     - Overview: usecases/overview.md
     - Data Analytics:
-      - Multi-Data Set Image Analysis in Taggit: usecases/haan/usecase-3.md
       - ML and AI: usecases/vantassel_and_zhang/usecase.md
       - Application Programming Interfaces: usecases/brandenberg-api/usecase.md
       - SQLite Database Management in DesignSafe: usecases/brandenberg-sqlite/usecase.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,8 @@ nav:
     - GIS Tools:
       - Hazmapper: tools/visualization/hazmapper.md
       - QGIS: tools/visualization/qgis.md
+      #- "Taggit: Basic Image Browsing and Mapping": tools/visualization/taggit-browse-map.md
+      #- "Taggit: Grouping and Tagging Image Files": tools/visualization/taggit-categorize.md
     - Visualization: tools/visualization.md
     - Hazard Apps: tools/hazard.md
     - Utilities: tools/utilities.md
@@ -148,6 +150,7 @@ nav:
   - Use Cases:
     - Overview: usecases/overview.md
     - Data Analytics:
+      #- Multi-Data Set Image Analysis in Taggit: usecases/haan/usecase-3.md
       - ML and AI: usecases/vantassel_and_zhang/usecase.md
       - Application Programming Interfaces: usecases/brandenberg-api/usecase.md
       - SQLite Database Management in DesignSafe: usecases/brandenberg-sqlite/usecase.md

--- a/user-guide/tools/visualization.md
+++ b/user-guide/tools/visualization.md
@@ -28,9 +28,7 @@
 
 ---
 
-<!-- {% include-markdown 'visualization/_redirect-taggit-browse-map.md' %} -->
-
-<!-- {% include-markdown 'visualization/_redirect-taggit-categorize.md' %} -->
+<!-- Taggit sections hidden; files preserved at visualization/_redirect-taggit-*.md -->
 
 ---
 

--- a/user-guide/tools/visualization.md
+++ b/user-guide/tools/visualization.md
@@ -28,11 +28,9 @@
 
 ---
 
-{% include-markdown 'visualization/_redirect-taggit-browse-map.md' %}
+<!-- {% include-markdown 'visualization/_redirect-taggit-browse-map.md' %} -->
 
----
-
-{% include-markdown 'visualization/_redirect-taggit-categorize.md' %}
+<!-- {% include-markdown 'visualization/_redirect-taggit-categorize.md' %} -->
 
 ---
 

--- a/user-guide/tools/visualization.md
+++ b/user-guide/tools/visualization.md
@@ -28,8 +28,12 @@
 
 ---
 
-<!-- Taggit sections hidden; files preserved at visualization/_redirect-taggit-*.md -->
+<!-- {% include-markdown 'visualization/_redirect-taggit-browse-map.md' %} -->
 
----
+<!-- --- -->
+
+<!-- {% include-markdown 'visualization/_redirect-taggit-categorize.md' %} -->
+
+<!-- --- -->
 
 {% include-markdown 'visualization/visit.md' %}

--- a/user-guide/tools/visualization.md
+++ b/user-guide/tools/visualization.md
@@ -28,11 +28,11 @@
 
 ---
 
-<!-- {% include-markdown 'visualization/_redirect-taggit-browse-map.md' %} -->
+<!-- include-markdown 'visualization/_redirect-taggit-browse-map.md' -->
 
 <!-- --- -->
 
-<!-- {% include-markdown 'visualization/_redirect-taggit-categorize.md' %} -->
+<!-- include-markdown 'visualization/_redirect-taggit-categorize.md' -->
 
 <!-- --- -->
 


### PR DESCRIPTION
## What Did You Change?

Hid Taggit from the user guide: commented out 3 nav entries in `mkdocs.yml` and removed the `include-markdown` directives from the visualization page. Files are preserved on disk.

<img width="780" height="460" alt="Screenshot 2026-07-09 at 16 47 11" src="https://github.com/user-attachments/assets/7ebc6634-f2d4-4ddd-81b1-adfd533d5533" />
