### PR TITLE
fix: relax mkdocs-tacc lower bound back to >=1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-  "mkdocs-tacc[all] (>=1.0.4,<2.0.0)",
+  "mkdocs-tacc[all] (>=1.0.0,<2.0.0)",
   "mkdocs-exclude-search (>=0.6.6,<0.7.0)",
   "mkdocs-include-markdown-plugin (>=5.1.0,<6.0.0)",
 ]


### PR DESCRIPTION
## What Did You Change?

Relaxed the `mkdocs-tacc` lower bound from `>=1.0.4` back to `>=1.0.0`. The patch pin added in #283 is unnecessary — `<2.0.0` is sufficient to get the latest 1.x.

## Do You Want Support (syntax, design, etc)?

N/A

<!-- After you open this PR, you can preview your changes. A comment will appear with a link to the server. -->

## Any Reference Material Worth Sharing?

N/A