### PR TITLE
feat: AI instructions + support Makefile command ARGS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+- [Architecture](#architecture)
+- [Commits](#commits)
+- [Pull Requests](#pull-requests)
+
+## Architecture
+
+This is a **MkDocs** project that can be run with `pip`, Poetry` or Docker. [Read more.](./README.md#developing)
+
+### Services
+
+| Service | Container | Port |
+| --- | --- | --- |
+| MkDocs | `designsafe_user_guide` | `localhost:8000` |
+
+### Make
+
+Use the `Makefile` instead of raw `docker compose` commands:
+
+| Command | Purpose |
+| --- | --- |
+| `make build` | Build Docker images |
+| `make start` | Start containers (`ARGS="--detach"` for background) |
+| `make stop` | Stop containers |
+
+### Lint, Test, Build
+
+- No linting software is configured.
+- Every PR automatically gets a preview server via Netlify.
+
+## Commits
+
+- **Format:** `.gitmessage` (fallback: `~/.gitmessage`)
+
+## Pull Requests
+
+- **Title:** `.gitmessage` (fallback: `~/.gitmessage`)
+- **Description:** `.github/PULL_REQUEST_TEMPLATE.md`
+  - Be concise: plain language, simple sentences; reviewers find detail in the diff. Say what changed, then why (if it matters) — never how.
+  - When updating, first re-read the current description, because it may have been edited.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ build:
 
 .PHONY: start
 start:
-	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml up
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.yml up $(ARGS)
 
 .PHONY: stop
 stop:
-	$(DOCKER_COMPOSE_CMD) -f docker-compose.yml down
+	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.yml down $(ARGS)


### PR DESCRIPTION
## What Did You Change?

Added support for AI developers.

## Do You Want Support (syntax, design, etc)?

No need. I've tested this on [TACC/Core-CMS](https://github.com/TACC/Core-CMS).

<!-- After you open this PR, you can preview your changes. A comment will appear with a link to the server. -->

## Any Reference Material Worth Sharing?

Claude is worth supporting[^1], but Claude does not recognize standard `AGENTS.md`, so I point `CLAUDE.md` to `AGENTS.md`.

[^1]: Claude is available to UT, thus available to TACC, which is responsible for docs architecture.